### PR TITLE
🪲 [Fix]: SHA used by linter should be docs commit

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -156,6 +156,8 @@ jobs:
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest
         env:
+          DEFAULT_BRANCH: main
+          DEFAULT_WORKSPACE: ${{ github.workspace }}
           GITHUB_TOKEN: ${{ github.token }}
           RUN_LOCAL: true
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -134,10 +134,10 @@ jobs:
     needs: BuildModule
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Init empty repository
+        shell: pwsh
+        run: |
+          git init --initial-branch=main
 
       - name: Download docs artifact
         uses: actions/download-artifact@v4
@@ -159,7 +159,7 @@ jobs:
           DEFAULT_BRANCH: main
           DEFAULT_WORKSPACE: ${{ github.workspace }}
           GITHUB_TOKEN: ${{ github.token }}
-          RUN_LOCAL: true
+          RUN_LOCAL: true # Running "locally" to avoid issues with the GitHub Actions environment.
           ENABLE_GITHUB_ACTIONS_GROUP_TITLE: true
 
   PublishModule:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -160,6 +160,7 @@ jobs:
           DEFAULT_WORKSPACE: ${{ github.workspace }}
           GITHUB_TOKEN: ${{ github.token }}
           RUN_LOCAL: true
+          ENABLE_GITHUB_ACTIONS_GROUP_TITLE: true
 
   PublishModule:
     name: Publish module

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -144,14 +144,14 @@ jobs:
         with:
           name: docs
 
-      # - name: Commit docs for linting
-      #   id: commit-docs
-      #   shell: pwsh
-      #   run: |
-      #     git config --global user.name "Github Actions"
-      #     git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      #     git add .
-      #     git commit -m "Update documentation"
+      - name: Commit docs for linting
+        id: commit-docs
+        shell: pwsh
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Update documentation"
 
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -145,6 +145,7 @@ jobs:
           name: docs
 
       - name: Commit docs for linting
+        id: commit-docs
         shell: pwsh
         run: |
           git config --global user.name "Github Actions"
@@ -153,13 +154,20 @@ jobs:
           git commit -m "Update documentation"
           $sha = git rev-parse HEAD
           Write-Verbose "SHA: $sha"
-          $env:GITHUB_SHA = $sha
+          "DOCSHA=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Commit docs for linting
+        shell: pwsh
+        run: |
+          Write-Verbose "SHA: $env:GITHUB_SHA"
+        env:
+          GITHUB_SHA: ${{ steps.commit-docs.outputs.DOCSHA }}
 
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_SHA: $sha
+          GITHUB_SHA: ${{ steps.commit-docs.outputs.DOCSHA }}
 
   PublishModule:
     name: Publish module

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -144,14 +144,14 @@ jobs:
         with:
           name: docs
 
-      - name: Commit docs for linting
-        id: commit-docs
-        shell: pwsh
-        run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "Update documentation"
+      # - name: Commit docs for linting
+      #   id: commit-docs
+      #   shell: pwsh
+      #   run: |
+      #     git config --global user.name "Github Actions"
+      #     git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      #     git add .
+      #     git commit -m "Update documentation"
 
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest
@@ -159,7 +159,7 @@ jobs:
           DEFAULT_BRANCH: main
           DEFAULT_WORKSPACE: ${{ github.workspace }}
           GITHUB_TOKEN: ${{ github.token }}
-          RUN_LOCAL: true # Running "locally" to avoid issues with the GitHub Actions environment.
+          RUN_LOCAL: true # Running "locally" to avoid issues with GITHUB_SHA issue of a squash merge.
           ENABLE_GITHUB_ACTIONS_GROUP_TITLE: true
 
   PublishModule:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -152,22 +152,12 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "Update documentation"
-          $sha = git rev-parse HEAD
-          Write-Verbose "SHA: $sha" -Verbose
-          "DOCSHA=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - name: Commit docs for linting
-        shell: pwsh
-        run: |
-          Write-Verbose "SHA: $env:GITHUB_SHA" -Verbose
-        env:
-          GITHUB_SHA: ${{ steps.commit-docs.outputs.DOCSHA }}
 
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_SHA: ${{ steps.commit-docs.outputs.DOCSHA }}
+          RUN_LOCAL: true
 
   PublishModule:
     name: Publish module

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -145,16 +145,21 @@ jobs:
           name: docs
 
       - name: Commit docs for linting
+        shell: pwsh
         run: |
           git config --global user.name "Github Actions"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "Update documentation"
+          $sha = git rev-parse HEAD
+          Write-Verbose "SHA: $sha"
+          $env:GITHUB_SHA = $sha
 
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_SHA: $sha
 
   PublishModule:
     name: Publish module

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -153,13 +153,13 @@ jobs:
           git add .
           git commit -m "Update documentation"
           $sha = git rev-parse HEAD
-          Write-Verbose "SHA: $sha"
+          Write-Verbose "SHA: $sha" -Verbose
           "DOCSHA=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Commit docs for linting
         shell: pwsh
         run: |
-          Write-Verbose "SHA: $env:GITHUB_SHA"
+          Write-Verbose "SHA: $env:GITHUB_SHA" -Verbose
         env:
           GITHUB_SHA: ${{ steps.commit-docs.outputs.DOCSHA }}
 

--- a/tests/src/PSModuleTest/public/New-PSModuleTest.ps1
+++ b/tests/src/PSModuleTest/public/New-PSModuleTest.ps1
@@ -3,7 +3,7 @@
 function New-PSModuleTest {
     <#
         .SYNOPSIS
-        Performs tests on a module.
+        Performs tests on a module. Repo.
 
         .EXAMPLE
         Test-PSModule -Name 'World'

--- a/tests/src/PSModuleTest/public/New-PSModuleTest.ps1
+++ b/tests/src/PSModuleTest/public/New-PSModuleTest.ps1
@@ -3,7 +3,7 @@
 function New-PSModuleTest {
     <#
         .SYNOPSIS
-        Performs tests on a module. Repo.
+        Performs tests on a module.
 
         .EXAMPLE
         Test-PSModule -Name 'World'


### PR DESCRIPTION
## Description

- Fixed an issue where docs linter would check more than docs.
- Fixed an issue where docs linter would fail due to SHA being that of the PR.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
