### PR TITLE
🪲 [Fix]: Setting PowerShellVersion correctly after tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -344,17 +344,18 @@ jobs:
           }
           Write-Host ($data | Format-Table | Out-String)
 
+          Set-ModuleManifest -Path $moduleManifestPath -PowerShellVersion '5.1'
+
           if ($Desktop) {
               Add-ModuleManifestData -Path $moduleManifestPath -CompatiblePSEditions 'Desktop'
               Add-ModuleManifestData -Path $moduleManifestPath -Tags 'PSEdition_Desktop'
+          } else {
+              Set-ModuleManifest -Path $moduleManifestPath -PowerShellVersion '7.0'
           }
 
           if ($Core) {
               Add-ModuleManifestData -Path $moduleManifestPath -CompatiblePSEditions 'Core'
               Add-ModuleManifestData -Path $moduleManifestPath -Tags 'PSEdition_Core'
-              Set-ModuleManifest -Path $moduleManifestPath -PowerShellVersion '7.0'
-          } else {
-              Set-ModuleManifest -Path $moduleManifestPath -PowerShellVersion '5.1'
           }
 
           if ($Linux) {


### PR DESCRIPTION
## Description

- Fix an issue where the version would be set incorrectly after tests.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
