### PR TITLE
🚀 [Feature]: Add ability to skip OS and shell specific tests

### DIFF
--- a/.github/workflows/Workflow-Test-Default.yml
+++ b/.github/workflows/Workflow-Test-Default.yml
@@ -23,3 +23,4 @@ jobs:
       ModulesOutputPath: tests/outputs/modules
       DocsOutputPath: tests/outputs/docs
       TestProcess: true
+      SkipTests: Module

--- a/.github/workflows/Workflow-Test-WithManifest.yml
+++ b/.github/workflows/Workflow-Test-WithManifest.yml
@@ -23,3 +23,4 @@ jobs:
       ModulesOutputPath: tests/outputs/modules
       DocsOutputPath: tests/outputs/docs
       TestProcess: true
+      SkipTests: Desktop, Linux

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,10 +27,10 @@ on:
         required: false
         default: outputs/docs
       SkipTests:
-        type: boolean
-        description: Whether to skip tests.
+        type: string
+        description: Defines what types of tests to skip. Allowed values are 'All', 'SourceCode', 'Module', 'None', 'MacOS', 'Windows', 'Linux', 'Desktop', 'Core'.
         required: false
-        default: false
+        default: None
       TestProcess:
         type: boolean
         description: Whether to test the process.
@@ -57,6 +57,7 @@ permissions:
 jobs:
   TestSourceCode-pwsh-ubuntu-latest:
     name: Test source code (pwsh, ubuntu-latest)
+    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'SourceCode') || contains(inputs.SkipTests, 'Linux') || contains(inputs.SkipTests, 'Core')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -72,7 +73,6 @@ jobs:
       - name: Test source code
         id: test
         uses: PSModule/Test-PSModule@v1
-        if: ${{ inputs.SkipTests != true }}
         with:
           Name: ${{ inputs.Name }}
           Path: ${{ inputs.Path }}
@@ -81,6 +81,7 @@ jobs:
 
   TestSourceCode-pwsh-macos-latest:
     name: Test source code (pwsh, macos-latest)
+    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'SourceCode' ) || contains(inputs.SkipTests, 'MacOS') || contains(inputs.SkipTests, 'Core')) }}
     runs-on: macos-latest
     outputs:
       passed: ${{ steps.test.outputs.passed }}
@@ -98,7 +99,6 @@ jobs:
       - name: Test source code
         id: test
         uses: PSModule/Test-PSModule@v1
-        if: ${{ inputs.SkipTests != true }}
         with:
           Name: ${{ inputs.Name }}
           Path: ${{ inputs.Path }}
@@ -107,6 +107,7 @@ jobs:
 
   TestSourceCode-pwsh-windows-latest:
     name: Test source code (pwsh, windows-latest)
+    if: ${{ !(contains(inputs.SkipTests, 'All' ) || contains(inputs.SkipTests, 'SourceCode' ) || contains(inputs.SkipTests, 'Windows') || contains(inputs.SkipTests, 'Core')) }}
     runs-on: windows-latest
     outputs:
       passed: ${{ steps.test.outputs.passed }}
@@ -124,7 +125,6 @@ jobs:
       - name: Test source code
         id: test
         uses: PSModule/Test-PSModule@v1
-        if: ${{ inputs.SkipTests != true }}
         with:
           Name: ${{ inputs.Name }}
           Path: ${{ inputs.Path }}
@@ -133,6 +133,7 @@ jobs:
 
   TestSourceCode-powershell-windows-latest:
     name: Test source code (powershell, windows-latest)
+    if: ${{ !(contains(inputs.SkipTests, 'All' ) || contains(inputs.SkipTests, 'SourceCode' ) || contains(inputs.SkipTests, 'Windows') || contains(inputs.SkipTests, 'Desktop')) }}
     runs-on: windows-latest
     outputs:
       passed: ${{ steps.test.outputs.passed }}
@@ -150,7 +151,6 @@ jobs:
       - name: Test source code
         id: test
         uses: PSModule/Test-PSModule@v1
-        if: ${{ inputs.SkipTests != true }}
         with:
           Name: ${{ inputs.Name }}
           Path: ${{ inputs.Path }}
@@ -202,6 +202,7 @@ jobs:
   #This is necessary as there is no way to get output from a matrix job
   TestModule-pwsh-ubuntu-latest:
     name: Test module (pwsh, ubuntu-latest)
+    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'Linux') || contains(inputs.SkipTests, 'Core')) }}
     needs: BuildModule
     runs-on: ubuntu-latest
     outputs:
@@ -226,7 +227,6 @@ jobs:
       - name: Test built module
         id: test
         uses: PSModule/Test-PSModule@v1
-        if: ${{ inputs.SkipTests != true }}
         continue-on-error: true
         with:
           Name: ${{ inputs.Name }}
@@ -241,6 +241,7 @@ jobs:
 
   TestModule-pwsh-macos-latest:
     name: Test module (pwsh, macos-latest)
+    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'MacOS') || contains(inputs.SkipTests, 'Core')) }}
     needs: BuildModule
     runs-on: macos-latest
     outputs:
@@ -265,7 +266,6 @@ jobs:
       - name: Test built module
         id: test
         uses: PSModule/Test-PSModule@v1
-        if: ${{ inputs.SkipTests != true }}
         continue-on-error: true
         with:
           Name: ${{ inputs.Name }}
@@ -280,6 +280,7 @@ jobs:
 
   TestModule-pwsh-windows-latest:
     name: Test module (pwsh, windows-latest)
+    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'Windows') || contains(inputs.SkipTests, 'Core')) }}
     needs: BuildModule
     runs-on: windows-latest
     outputs:
@@ -304,7 +305,6 @@ jobs:
       - name: Test built module
         id: test
         uses: PSModule/Test-PSModule@v1
-        if: ${{ inputs.SkipTests != true }}
         continue-on-error: true
         with:
           Name: ${{ inputs.Name }}
@@ -319,6 +319,7 @@ jobs:
 
   TestModule-powershell-windows-latest:
     name: Test module (powershell, windows-latest)
+    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'Windows') || contains(inputs.SkipTests, 'Desktop')) }}
     needs: BuildModule
     runs-on: windows-latest
     outputs:
@@ -343,7 +344,6 @@ jobs:
       - name: Test built module
         id: test
         uses: PSModule/Test-PSModule@v1
-        if: ${{ inputs.SkipTests != true }}
         continue-on-error: true
         with:
           Name: ${{ inputs.Name }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -55,17 +55,9 @@ permissions:
   statuses: write
 
 jobs:
-  TestSourceCode:
-    name: Test code
-    strategy:
-      fail-fast: false
-      matrix:
-        shell: [pwsh]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - shell: powershell
-            os: windows-latest
-    runs-on: ${{ matrix.os }}
+  TestSourceCode-pwsh-ubuntu-latest:
+    name: Test source code (pwsh, ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -75,20 +67,103 @@ jobs:
         with:
           Version: ${{ inputs.Version }}
           Prerelease: ${{ inputs.Prerelease }}
-          Shell: ${{ matrix.shell }}
+          Shell: pwsh
 
-      - name: Test built module
+      - name: Test source code
+        id: test
         uses: PSModule/Test-PSModule@v1
         if: ${{ inputs.SkipTests != true }}
         with:
           Name: ${{ inputs.Name }}
           Path: ${{ inputs.Path }}
-          Shell: ${{ matrix.shell }}
+          Shell: pwsh
+          TestType: SourceCode
+
+  TestSourceCode-pwsh-macos-latest:
+    name: Test source code (pwsh, macos-latest)
+    runs-on: macos-latest
+    outputs:
+      passed: ${{ steps.test.outputs.passed }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Initialize environment
+        uses: PSModule/Initialize-PSModule@v1
+        with:
+          Version: ${{ inputs.Version }}
+          Prerelease: ${{ inputs.Prerelease }}
+          Shell: pwsh
+
+      - name: Test source code
+        id: test
+        uses: PSModule/Test-PSModule@v1
+        if: ${{ inputs.SkipTests != true }}
+        with:
+          Name: ${{ inputs.Name }}
+          Path: ${{ inputs.Path }}
+          Shell: pwsh
+          TestType: SourceCode
+
+  TestSourceCode-pwsh-windows-latest:
+    name: Test source code (pwsh, windows-latest)
+    runs-on: windows-latest
+    outputs:
+      passed: ${{ steps.test.outputs.passed }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Initialize environment
+        uses: PSModule/Initialize-PSModule@v1
+        with:
+          Version: ${{ inputs.Version }}
+          Prerelease: ${{ inputs.Prerelease }}
+          Shell: pwsh
+
+      - name: Test source code
+        id: test
+        uses: PSModule/Test-PSModule@v1
+        if: ${{ inputs.SkipTests != true }}
+        with:
+          Name: ${{ inputs.Name }}
+          Path: ${{ inputs.Path }}
+          Shell: pwsh
+          TestType: SourceCode
+
+  TestSourceCode-powershell-windows-latest:
+    name: Test source code (powershell, windows-latest)
+    runs-on: windows-latest
+    outputs:
+      passed: ${{ steps.test.outputs.passed }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Initialize environment
+        uses: PSModule/Initialize-PSModule@v1
+        with:
+          Version: ${{ inputs.Version }}
+          Prerelease: ${{ inputs.Prerelease }}
+          Shell: powershell
+
+      - name: Test source code
+        id: test
+        uses: PSModule/Test-PSModule@v1
+        if: ${{ inputs.SkipTests != true }}
+        with:
+          Name: ${{ inputs.Name }}
+          Path: ${{ inputs.Path }}
+          Shell: powershell
           TestType: SourceCode
 
   BuildModule:
     name: Build module
-    needs: TestSourceCode
+    needs:
+      - TestSourceCode-pwsh-ubuntu-latest
+      - TestSourceCode-pwsh-macos-latest
+      - TestSourceCode-pwsh-windows-latest
+      - TestSourceCode-powershell-windows-latest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -403,27 +403,33 @@ jobs:
           $Status = @(
               [pscustomobject]@{
                   Name    = 'Linux'
-                  Status  = $linuxSkipped ? '⚠️ (Skipped)' : $linuxPassed ? '✅ (Passed)' : '❌ (Failed)'
+                  Status  = $linuxSkipped ? 'Skipped' : $linuxPassed ? 'Passed' : 'Failed'
+                  Icon    = $linuxSkipped ? '⚠️' : $linuxPassed ? '✅' : '❌'
               }
               [pscustomobject]@{
                   Name    = 'MacOS'
-                  Status  = $macOSSkipped ? '⚠️ (Skipped)' : $macOSPassed ? '✅ (Passed)' : '❌ (Failed)'
+                  Status  = $macOSSkipped ? 'Skipped' : $macOSPassed ? 'Passed' : 'Failed'
+                  Icon    = $macOSSkipped ? '⚠️' : $macOSPassed ? '✅' : '❌'
               }
               [pscustomobject]@{
                   Name    = 'Windows'
-                  Status  = $windowsSkipped ? '⚠️ (Skipped)' : $windowsPassed ? '✅ (Passed)' : '❌ (Failed)'
+                  Status  = $windowsSkipped ? 'Skipped' : $windowsPassed ? 'Passed' : 'Failed'
+                  Icon    = $windowsSkipped ? '⚠️' : $windowsPassed ? '✅' : '❌'
               }
               [pscustomobject]@{
                   Name    = 'Desktop'
-                  Status  = $desktopSkipped ? '⚠️ (Skipped)' : $desktopPassed ? '✅ (Passed)' : '❌ (Failed)'
+                  Status  = $desktopSkipped ? 'Skipped' : $desktopPassed ? 'Passed' : 'Failed'
+                  Icon    = $desktopSkipped ? '⚠️' : $desktopPassed ? '✅' : '❌'
               }
               [pscustomobject]@{
                   Name    = 'Core'
-                  Status  = $coreSkipped ? '⚠️ (Skipped)' : $corePassed ? '✅ (Passed)' : '❌ (Failed)'
+                  Status  = $coreSkipped ? 'Skipped' : $corePassed ? 'Passed' : 'Failed'
+                  Icon    = $coreSkipped ? '⚠️' : $corePassed ? '✅' : '❌'
               }
               [pscustomobject]@{
                   Name    = 'All'
-                  Status  = $allSkipped ? '⚠️ (Skipped)' : $allPassed ? '✅ (Passed)' : '❌ (Failed)'
+                  Status  = $allSkipped ? 'Skipped' : $allPassed ? 'Passed' : 'Failed'
+                  Icon    = $allSkipped ? '⚠️' : $allPassed ? '✅' : '❌'
               }
           )
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ on:
         default: outputs/docs
       SkipTests:
         type: string
-        description: Defines what types of tests to skip. Allowed values are 'All', 'SourceCode', 'Module', 'None', 'MacOS', 'Windows', 'Linux', 'Desktop', 'Core'.
+        description: Defines what types of tests to skip. Allowed values are 'All', 'SourceCode', 'Module', 'None', 'macOS', 'Windows', 'Linux', 'Desktop', 'Core'.
         required: false
         default: None
       TestProcess:
@@ -81,7 +81,7 @@ jobs:
 
   TestSourceCode-pwsh-macos-latest:
     name: Test source code (pwsh, macos-latest)
-    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'SourceCode' ) || contains(inputs.SkipTests, 'MacOS') || contains(inputs.SkipTests, 'Core')) }}
+    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'SourceCode' ) || contains(inputs.SkipTests, 'macOS') || contains(inputs.SkipTests, 'Core')) }}
     runs-on: macos-latest
     outputs:
       passed: ${{ steps.test.outputs.passed }}
@@ -241,7 +241,7 @@ jobs:
 
   TestModule-pwsh-macos-latest:
     name: Test module (pwsh, macos-latest)
-    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'MacOS') || contains(inputs.SkipTests, 'Core')) }}
+    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'macOS') || contains(inputs.SkipTests, 'Core')) }}
     needs: BuildModule
     runs-on: macos-latest
     outputs:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -387,41 +387,56 @@ jobs:
         run: |
           Start-LogGroup -Name 'Passed tests'
 
+          $linuxPassed = '${{ needs.TestModule-pwsh-ubuntu-latest.outputs.passed }}' -eq 'true'
+          $linuxSkipped = '${{ needs.TestModule-pwsh-ubuntu-latest.result }}' -eq 'skipped'
+          $macOSPassed = '${{ needs.TestModule-pwsh-macos-latest.outputs.passed }}' -eq 'true'
+          $macOSSkipped = '${{ needs.TestModule-pwsh-macos-latest.result }}' -eq 'skipped'
+          $windowsPassed = '${{ needs.TestModule-pwsh-windows-latest.outputs.passed }}' -eq 'true'
+          $windowsSkipped = '${{ needs.TestModule-pwsh-windows-latest.result }}' -eq 'skipped'
+          $desktopPassed = '${{ needs.TestModule-powershell-windows-latest.outputs.passed }}' -eq 'true'
+          $desktopSkipped = '${{ needs.TestModule-powershell-windows-latest.result }}' -eq 'skipped'
+          $corePassed = $linuxPassed -and $macOSPassed -and $windowsPassed
+          $coreSkipped = $linuxSkipped -and $macOSSkipped -and $windowsSkipped
+          $allPassed = $corePassed -and $desktopPassed
+          $allSkipped = $coreSkipped -and $desktopSkipped
+
           $Status = @{
               Linux = [pscustomobject]@{
                   Name    = 'Linux'
-                  Passed  = '${{ needs.TestModule-pwsh-ubuntu-latest.outputs.passed }}' -eq 'true'
-                  Skipped = '${{ needs.TestModule-pwsh-ubuntu-latest.result }}' -eq 'skipped'
+                  Passed  = $linuxPassed ? '✅' : '❌'
+                  Skipped = $linuxSkipped ? '✅' : '❌'
               }
               MacOS = [pscustomobject]@{
                   Name    = 'MacOS'
-                  Passed  = '${{ needs.TestModule-pwsh-macos-latest.outputs.passed }}' -eq 'true'
-                  Skipped = '${{ needs.TestModule-pwsh-macos-latest.result }}' -eq 'skipped'
+                  Passed  = $macOSPassed ? '✅' : '❌'
+                  Skipped = $macOSSkipped ? '✅' : '❌'
               }
               Windows = [pscustomobject]@{
                   Name    = 'Windows'
-                  Passed  = '${{ needs.TestModule-pwsh-windows-latest.outputs.passed }}' -eq 'true'
-                  Skipped = '${{ needs.TestModule-pwsh-windows-latest.result }}' -eq 'skipped'
+                  Passed  = $windowsPassed ? '✅' : '❌'
+                  Skipped = $windowsSkipped ? '✅' : '❌'
               }
               Desktop = [pscustomobject]@{
                   Name    = 'Desktop'
-                  Passed  = '${{ needs.TestModule-powershell-windows-latest.outputs.passed }}' -eq 'true'
-                  Skipped = '${{ needs.TestModule-powershell-windows-latest.result }}' -eq 'skipped'
+                  Passed  = $desktopPassed ? '✅' : '❌'
+                  Skipped = $desktopSkipped ? '✅' : '❌'
               }
               Core = [pscustomobject]@{
                   Name    = 'Core'
-                  Passed  = $Status['Linux'].Passed -and $Status['MacOS'].Passed -and $Status['Windows'].Passed
-                  Skipped = $Status['Linux'].Skipped -and $Status['MacOS'].Skipped -and $Status['Windows'].Skipped
+                  Passed  = $corePassed ? '✅' : '❌'
+                  Skipped = $coreSkipped ? '✅' : '❌'
+              }
+              All = [pscustomobject]@{
+                  Name    = 'All'
+                  Passed  = $allPassed ? '✅' : '❌'
+                  Skipped = $allSkipped ? '✅' : '❌'
               }
           }
 
           Write-Host ($Status | Format-Table |  Out-String)
-
-          $passedAll = $Status['Core'].Passed -and $Status['Desktop'].Passed
-          $skippedAll = $Status['Core'].Skipped -and $Status['Desktop'].Skipped
           Stop-LogGroup
 
-          if (-not $passedAll -and -not $skippedAll) {
+          if (-not $allPassed -and -not $allSkipped) {
               Write-Host "::[error]::No tests passed"
               exit 1
           }

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -433,7 +433,8 @@ jobs:
               }
           )
 
-          Write-Host ($Status | Format-List |  Out-String)
+          Write-Host ($Status | Format-Table | Out-String)
+          Write-Host ($Status | New-MDTable)
           Stop-LogGroup
 
           if (-not $passed -and -not $skipped) {

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -159,7 +159,7 @@ jobs:
 
   BuildModule:
     name: Build module
-    if: ${{ contains(fromJson('["success","skipped"]'), needs.TestSourceCode-pwsh-ubuntu-latest.result) && contains(fromJson('["success","skipped"]'), needs.TestSourceCode-pwsh-macos-latest.result) && contains(fromJson('["success","skipped"]'), needs.TestSourceCode-pwsh-windows-latest.result) && contains(fromJson('["success","skipped"]'), needs.TestSourceCode-powershell-windows-latest.result) }}
+    if: ${{ contains(fromJson('["success", "skipped"]'), needs.TestSourceCode-pwsh-ubuntu-latest.result) && contains(fromJson('["success", "skipped"]'), needs.TestSourceCode-pwsh-macos-latest.result) && contains(fromJson('["success", "skipped"]'), needs.TestSourceCode-pwsh-windows-latest.result) && contains(fromJson('["success", "skipped"]'), needs.TestSourceCode-powershell-windows-latest.result) && !cancelled() }}
     needs:
       - TestSourceCode-pwsh-ubuntu-latest
       - TestSourceCode-pwsh-macos-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -400,38 +400,32 @@ jobs:
           $allPassed = $corePassed -and $desktopPassed
           $allSkipped = $coreSkipped -and $desktopSkipped
 
-          $Status = @{
-              Linux = [pscustomobject]@{
+          $Status = @(
+              [pscustomobject]@{
                   Name    = 'Linux'
-                  Passed  = $linuxPassed ? '✅' : '❌'
-                  Skipped = $linuxSkipped ? '✅' : '❌'
+                  Status  = $linuxSkipped ? '⚠️ (Skipped)' : $linuxPassed ? '✅ (Passed)' : '❌ (Failed)'
               }
-              MacOS = [pscustomobject]@{
+              [pscustomobject]@{
                   Name    = 'MacOS'
-                  Passed  = $macOSPassed ? '✅' : '❌'
-                  Skipped = $macOSSkipped ? '✅' : '❌'
+                  Status  = $macOSSkipped ? '⚠️ (Skipped)' : $macOSPassed ? '✅ (Passed)' : '❌ (Failed)'
               }
-              Windows = [pscustomobject]@{
+              [pscustomobject]@{
                   Name    = 'Windows'
-                  Passed  = $windowsPassed ? '✅' : '❌'
-                  Skipped = $windowsSkipped ? '✅' : '❌'
+                  Status  = $windowsSkipped ? '⚠️ (Skipped)' : $windowsPassed ? '✅ (Passed)' : '❌ (Failed)'
               }
-              Desktop = [pscustomobject]@{
+              [pscustomobject]@{
                   Name    = 'Desktop'
-                  Passed  = $desktopPassed ? '✅' : '❌'
-                  Skipped = $desktopSkipped ? '✅' : '❌'
+                  Status  = $desktopSkipped ? '⚠️ (Skipped)' : $desktopPassed ? '✅ (Passed)' : '❌ (Failed)'
               }
-              Core = [pscustomobject]@{
+              [pscustomobject]@{
                   Name    = 'Core'
-                  Passed  = $corePassed ? '✅' : '❌'
-                  Skipped = $coreSkipped ? '✅' : '❌'
+                  Status  = $coreSkipped ? '⚠️ (Skipped)' : $corePassed ? '✅ (Passed)' : '❌ (Failed)'
               }
-              All = [pscustomobject]@{
+              [pscustomobject]@{
                   Name    = 'All'
-                  Passed  = $allPassed ? '✅' : '❌'
-                  Skipped = $allSkipped ? '✅' : '❌'
+                  Status  = $allSkipped ? '⚠️ (Skipped)' : $allPassed ? '✅ (Passed)' : '❌ (Failed)'
               }
-          }
+          )
 
           Write-Host ($Status | Format-Table |  Out-String)
           Stop-LogGroup

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -437,7 +437,7 @@ jobs:
           Write-Host ($Status | New-MDTable)
           Stop-LogGroup
 
-          if (-not $passed -and -not $skipped) {
+          if (-not $anyPassed -and -not $allSkipped) {
               Write-Host "::[error]::No tests passed"
               exit 1
           }

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -159,6 +159,7 @@ jobs:
 
   BuildModule:
     name: Build module
+    if: ${{ contains(fromJson('["success","skipped"]'), needs.TestSourceCode-pwsh-ubuntu-latest.result) && contains(fromJson('["success","skipped"]'), needs.TestSourceCode-pwsh-macos-latest.result) && contains(fromJson('["success","skipped"]'), needs.TestSourceCode-pwsh-windows-latest.result) && contains(fromJson('["success","skipped"]'), needs.TestSourceCode-powershell-windows-latest.result) }}
     needs:
       - TestSourceCode-pwsh-ubuntu-latest
       - TestSourceCode-pwsh-macos-latest
@@ -364,7 +365,7 @@ jobs:
       - TestModule-pwsh-windows-latest
       - TestModule-powershell-windows-latest
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: success() || failure()
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -494,7 +495,7 @@ jobs:
 
   PublishModule:
     name: Publish module
-    if: ${{ needs.TestModuleStatus.result == 'success' && needs.LintDocs.result == 'success' && !cancelled() }}
+    if: ${{ needs.TestModuleStatus.result == 'success' && needs.LintDocs.result == 'success' && (success() || failure()) }}
     needs:
       - TestModuleStatus
       - LintDocs

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -434,7 +434,7 @@ jobs:
           )
 
           Write-Host ($Status | Format-Table | Out-String)
-          Write-Host ($Status | New-MDTable)
+          ($Status | New-MDTable) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
           Stop-LogGroup
 
           if (-not $anyPassed -and -not $allSkipped) {

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -364,7 +364,7 @@ jobs:
       - TestModule-pwsh-windows-latest
       - TestModule-powershell-windows-latest
     runs-on: ubuntu-latest
-    if: success() || failure()
+    if: !cancelled()
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -494,7 +494,7 @@ jobs:
 
   PublishModule:
     name: Publish module
-    if: ${{ needs.TestModuleStatus.result == 'success' && needs.LintDocs.result == 'success' && (success() || failure()) }}
+    if: ${{ needs.TestModuleStatus.result == 'success' && needs.LintDocs.result == 'success' && !cancelled() }}
     needs:
       - TestModuleStatus
       - LintDocs

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -385,28 +385,46 @@ jobs:
       - name: Summerize tests
         shell: pwsh
         run: |
-          Start-LogGroup -Name 'Status'
-          $Linux = '${{ needs.TestModule-pwsh-ubuntu-latest.outputs.passed }}' -eq 'true'
-          $MacOS = '${{ needs.TestModule-pwsh-macos-latest.outputs.passed }}' -eq 'true'
-          $Windows = '${{ needs.TestModule-pwsh-windows-latest.outputs.passed }}' -eq 'true'
-          $Desktop = '${{ needs.TestModule-powershell-windows-latest.outputs.passed }}' -eq 'true'
-          $Core = $Linux -or $MacOS -or $Windows
+          Start-LogGroup -Name 'Passed tests'
 
-          $Status = [pscustomobject]@{
-              Linux   = $Linux
-              MacOS   = $MacOS
-              Windows = $Windows
-              Desktop = $Desktop
-              Core    = $Core
+          $Status = @{
+              Linux = [pscustomobject]@{
+                  Name    = 'Linux'
+                  Passed  = '${{ needs.TestModule-pwsh-ubuntu-latest.outputs.passed }}' -eq 'true'
+                  Skipped = '${{ needs.TestModule-pwsh-ubuntu-latest.result }}' -eq 'skipped'
+              }
+              MacOS = [pscustomobject]@{
+                  Name    = 'MacOS'
+                  Passed  = '${{ needs.TestModule-pwsh-macos-latest.outputs.passed }}' -eq 'true'
+                  Skipped = '${{ needs.TestModule-pwsh-macos-latest.result }}' -eq 'skipped'
+              }
+              Windows = [pscustomobject]@{
+                  Name    = 'Windows'
+                  Passed  = '${{ needs.TestModule-pwsh-windows-latest.outputs.passed }}' -eq 'true'
+                  Skipped = '${{ needs.TestModule-pwsh-windows-latest.result }}' -eq 'skipped'
+              }
+              Desktop = [pscustomobject]@{
+                  Name    = 'Desktop'
+                  Passed  = '${{ needs.TestModule-powershell-windows-latest.outputs.passed }}' -eq 'true'
+                  Skipped = '${{ needs.TestModule-powershell-windows-latest.result }}' -eq 'skipped'
+              }
+              Core = [pscustomobject]@{
+                  Name    = 'Core'
+                  Passed  = $Status['Linux'].Passed -and $Status['MacOS'].Passed -and $Status['Windows'].Passed
+                  Skipped = $Status['Linux'].Skipped -and $Status['MacOS'].Skipped -and $Status['Windows'].Skipped
+              }
           }
 
           Write-Host ($Status | Format-Table |  Out-String)
 
-          if (-not ($Core -or $Desktop)) {
+          $passedAll = $Status['Core'].Passed -and $Status['Desktop'].Passed
+          $skippedAll = $Status['Core'].Skipped -and $Status['Desktop'].Skipped
+          Stop-LogGroup
+
+          if (-not $passedAll -and -not $skippedAll) {
               Write-Host "::[error]::No tests passed"
               exit 1
           }
-          Stop-LogGroup
 
           Start-LogGroup -Name 'Data'
           $moduleName = [string]::IsNullOrEmpty('${{ inputs.Name }}') ? $env:GITHUB_REPOSITORY_NAME : '${{ inputs.Name }}'
@@ -421,6 +439,8 @@ jobs:
           Write-Host ($data | Format-Table | Out-String)
 
           Set-ModuleManifest -Path $moduleManifestPath -PowerShellVersion '5.1'
+
+          #TODO: DONT OVERRIDE MANIFEST
 
           if ($Desktop) {
               Add-ModuleManifestData -Path $moduleManifestPath -CompatiblePSEditions 'Desktop'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -397,8 +397,8 @@ jobs:
           $desktopSkipped = '${{ needs.TestModule-powershell-windows-latest.result }}' -eq 'skipped'
           $corePassed = $linuxPassed -or $macOSPassed -or $windowsPassed
           $coreSkipped = $linuxSkipped -and $macOSSkipped -and $windowsSkipped
-          $passed = $corePassed -and $desktopPassed
-          $skipped = $coreSkipped -and $desktopSkipped
+          $anyPassed = $corePassed -or $desktopPassed
+          $allSkipped = $coreSkipped -and $desktopSkipped
 
           $Status = @(
               [pscustomobject]@{
@@ -428,8 +428,8 @@ jobs:
               }
               [pscustomobject]@{
                   Name    = 'Result'
-                  Icon    = $skipped ? '⚠️' : $passed ? '✅' : '❌'
-                  Status  = $skipped ? 'Skipped' : $passed ? 'Passed' : 'Failed'
+                  Icon    = $allSkipped ? '⚠️' : $anyPassed ? '✅' : '❌'
+                  Status  = $allSkipped ? 'Skipped' : $anyPassed ? 'Passed' : 'Failed'
               }
           )
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -364,7 +364,7 @@ jobs:
       - TestModule-pwsh-windows-latest
       - TestModule-powershell-windows-latest
     runs-on: ubuntu-latest
-    if: !cancelled()
+    if: ${{ !cancelled() }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -203,7 +203,7 @@ jobs:
   #This is necessary as there is no way to get output from a matrix job
   TestModule-pwsh-ubuntu-latest:
     name: Test module (pwsh, ubuntu-latest)
-    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'Linux') || contains(inputs.SkipTests, 'Core')) }}
+    if: ${{ needs.BuildModule.result == 'success' && !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'Linux') || contains(inputs.SkipTests, 'Core')) && !cancelled() }}
     needs: BuildModule
     runs-on: ubuntu-latest
     outputs:
@@ -242,7 +242,7 @@ jobs:
 
   TestModule-pwsh-macos-latest:
     name: Test module (pwsh, macos-latest)
-    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'macOS') || contains(inputs.SkipTests, 'Core')) }}
+    if: ${{ needs.BuildModule.result == 'success' && !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'macOS') || contains(inputs.SkipTests, 'Core')) && !cancelled() }}
     needs: BuildModule
     runs-on: macos-latest
     outputs:
@@ -281,7 +281,7 @@ jobs:
 
   TestModule-pwsh-windows-latest:
     name: Test module (pwsh, windows-latest)
-    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'Windows') || contains(inputs.SkipTests, 'Core')) }}
+    if: ${{ needs.BuildModule.result == 'success' && !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'Windows') || contains(inputs.SkipTests, 'Core')) && !cancelled() }}
     needs: BuildModule
     runs-on: windows-latest
     outputs:
@@ -320,7 +320,7 @@ jobs:
 
   TestModule-powershell-windows-latest:
     name: Test module (powershell, windows-latest)
-    if: ${{ !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'Windows') || contains(inputs.SkipTests, 'Desktop')) }}
+    if: ${{ needs.BuildModule.result == 'success' && !(contains(inputs.SkipTests, 'All') || contains(inputs.SkipTests, 'Module') || contains(inputs.SkipTests, 'Windows') || contains(inputs.SkipTests, 'Desktop')) && !cancelled() }}
     needs: BuildModule
     runs-on: windows-latest
     outputs:
@@ -359,13 +359,13 @@ jobs:
 
   TestModuleStatus:
     name: Test module status
+    if: ${{ contains(fromJson('["success", "skipped"]'), needs.TestModule-pwsh-ubuntu-latest.result) && contains(fromJson('["success", "skipped"]'), needs.TestModule-pwsh-macos-latest.result) && contains(fromJson('["success", "skipped"]'), needs.TestModule-pwsh-windows-latest.result) && contains(fromJson('["success", "skipped"]'), needs.TestModule-powershell-windows-latest.result) && !cancelled() }}
     needs:
       - TestModule-pwsh-ubuntu-latest
       - TestModule-pwsh-macos-latest
       - TestModule-pwsh-windows-latest
       - TestModule-powershell-windows-latest
     runs-on: ubuntu-latest
-    if: success() || failure()
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -462,6 +462,7 @@ jobs:
 
   LintDocs:
     name: Lint documentation
+    if: ${{ needs.BuildModule.result == 'success' && !cancelled() }}
     needs: BuildModule
     runs-on: ubuntu-latest
     steps:
@@ -495,7 +496,7 @@ jobs:
 
   PublishModule:
     name: Publish module
-    if: ${{ needs.TestModuleStatus.result == 'success' && needs.LintDocs.result == 'success' && (success() || failure()) }}
+    if: ${{ needs.TestModuleStatus.result == 'success' && needs.LintDocs.result == 'success' && !cancelled() }}
     needs:
       - TestModuleStatus
       - LintDocs

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -395,48 +395,48 @@ jobs:
           $windowsSkipped = '${{ needs.TestModule-pwsh-windows-latest.result }}' -eq 'skipped'
           $desktopPassed = '${{ needs.TestModule-powershell-windows-latest.outputs.passed }}' -eq 'true'
           $desktopSkipped = '${{ needs.TestModule-powershell-windows-latest.result }}' -eq 'skipped'
-          $corePassed = $linuxPassed -and $macOSPassed -and $windowsPassed
+          $corePassed = $linuxPassed -or $macOSPassed -or $windowsPassed
           $coreSkipped = $linuxSkipped -and $macOSSkipped -and $windowsSkipped
-          $allPassed = $corePassed -and $desktopPassed
-          $allSkipped = $coreSkipped -and $desktopSkipped
+          $passed = $corePassed -and $desktopPassed
+          $skipped = $coreSkipped -and $desktopSkipped
 
           $Status = @(
               [pscustomobject]@{
                   Name    = 'Linux'
-                  Status  = $linuxSkipped ? 'Skipped' : $linuxPassed ? 'Passed' : 'Failed'
                   Icon    = $linuxSkipped ? '⚠️' : $linuxPassed ? '✅' : '❌'
+                  Status  = $linuxSkipped ? 'Skipped' : $linuxPassed ? 'Passed' : 'Failed'
               }
               [pscustomobject]@{
                   Name    = 'MacOS'
-                  Status  = $macOSSkipped ? 'Skipped' : $macOSPassed ? 'Passed' : 'Failed'
                   Icon    = $macOSSkipped ? '⚠️' : $macOSPassed ? '✅' : '❌'
+                  Status  = $macOSSkipped ? 'Skipped' : $macOSPassed ? 'Passed' : 'Failed'
               }
               [pscustomobject]@{
                   Name    = 'Windows'
-                  Status  = $windowsSkipped ? 'Skipped' : $windowsPassed ? 'Passed' : 'Failed'
                   Icon    = $windowsSkipped ? '⚠️' : $windowsPassed ? '✅' : '❌'
+                  Status  = $windowsSkipped ? 'Skipped' : $windowsPassed ? 'Passed' : 'Failed'
               }
               [pscustomobject]@{
                   Name    = 'Desktop'
-                  Status  = $desktopSkipped ? 'Skipped' : $desktopPassed ? 'Passed' : 'Failed'
                   Icon    = $desktopSkipped ? '⚠️' : $desktopPassed ? '✅' : '❌'
+                  Status  = $desktopSkipped ? 'Skipped' : $desktopPassed ? 'Passed' : 'Failed'
               }
               [pscustomobject]@{
                   Name    = 'Core'
-                  Status  = $coreSkipped ? 'Skipped' : $corePassed ? 'Passed' : 'Failed'
                   Icon    = $coreSkipped ? '⚠️' : $corePassed ? '✅' : '❌'
+                  Status  = $coreSkipped ? 'Skipped' : $corePassed ? 'Passed' : 'Failed'
               }
               [pscustomobject]@{
-                  Name    = 'All'
-                  Status  = $allSkipped ? 'Skipped' : $allPassed ? 'Passed' : 'Failed'
-                  Icon    = $allSkipped ? '⚠️' : $allPassed ? '✅' : '❌'
+                  Name    = 'Result'
+                  Icon    = $skipped ? '⚠️' : $passed ? '✅' : '❌'
+                  Status  = $skipped ? 'Skipped' : $passed ? 'Passed' : 'Failed'
               }
           )
 
           Write-Host ($Status | Format-Table |  Out-String)
           Stop-LogGroup
 
-          if (-not $allPassed -and -not $allSkipped) {
+          if (-not $passed -and -not $skipped) {
               Write-Host "::[error]::No tests passed"
               exit 1
           }

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -433,7 +433,7 @@ jobs:
               }
           )
 
-          Write-Host ($Status | Format-Table |  Out-String)
+          Write-Host ($Status | Format-List |  Out-String)
           Stop-LogGroup
 
           if (-not $passed -and -not $skipped) {

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ jobs:
 | `Path` | `string` | The path to the source code of the module. | `false` | `src` |
 | `ModulesOutputPath` | `string` | The path to the output directory for the modules. | `false` | `outputs/modules` |
 | `DocsOutputPath` | `string` | The path to the output directory for the documentation. | `false` | `outputs/docs` |
-| `SkipTests` | `boolean` | Whether to skip the tests. | false | `false` |
+| `SkipTests` | `string` | Defines what types of tests to skip. Allowed values are 'All', 'SourceCode', 'Module', 'None', 'MacOS', 'Windows', 'Linux', 'Desktop', 'Core'. | false | `None` |
 | `TestProcess` | `boolean` | Whether to test the process. | false | `false` |
 
 ### Secrets

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ jobs:
 | `Path` | `string` | The path to the source code of the module. | `false` | `src` |
 | `ModulesOutputPath` | `string` | The path to the output directory for the modules. | `false` | `outputs/modules` |
 | `DocsOutputPath` | `string` | The path to the output directory for the documentation. | `false` | `outputs/docs` |
-| `SkipTests` | `string` | Defines what types of tests to skip. Allowed values are 'All', 'SourceCode', 'Module', 'None', 'MacOS', 'Windows', 'Linux', 'Desktop', 'Core'. | false | `None` |
+| `SkipTests` | `string` | Defines what types of tests to skip. Allowed values are 'All', 'SourceCode', 'Module', 'None', 'macOS', 'Windows', 'Linux', 'Desktop', 'Core'. | false | `None` |
 | `TestProcess` | `boolean` | Whether to test the process. | false | `false` |
 
 ### Secrets


### PR DESCRIPTION
## Description

- Adds the ability to use a parameter to skip specific tests:
  - `SkipTests = 'All'` - Skips all tests
  - `SkipTests = 'MacOS'` - Skips tests on MacOS
  - `SkipTests = 'Core'` - Skips pwsh tests (Ubuntu + MacOS + Windows(pwsh)), but still runs Windows PowerShell tests.
  - Fixes #24 

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
