### PR TITLE
🪲 [Fix]: Tags and PS Version not being set in manifest after tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -452,33 +452,31 @@ jobs:
             Path               = $path
             ModuleManifestPath = $moduleManifestPath
           }
-          Write-Host ($data | Format-Table | Out-String)
+          Write-Verbose ($data | Format-List | Out-String) -Verbose
 
           Set-ModuleManifest -Path $moduleManifestPath -PowerShellVersion '5.1'
 
-          #TODO: DONT OVERRIDE MANIFEST
-
-          if ($Desktop) {
+          if ($desktopPassed) {
               Add-ModuleManifestData -Path $moduleManifestPath -CompatiblePSEditions 'Desktop'
               Add-ModuleManifestData -Path $moduleManifestPath -Tags 'PSEdition_Desktop'
           } else {
               Set-ModuleManifest -Path $moduleManifestPath -PowerShellVersion '7.0'
           }
 
-          if ($Core) {
+          if ($corePassed) {
               Add-ModuleManifestData -Path $moduleManifestPath -CompatiblePSEditions 'Core'
               Add-ModuleManifestData -Path $moduleManifestPath -Tags 'PSEdition_Core'
           }
 
-          if ($Linux) {
+          if ($linuxPassed) {
               Add-ModuleManifestData -Path $moduleManifestPath -Tags 'Linux'
           }
 
-          if ($MacOS) {
+          if ($macOSPassed) {
               Add-ModuleManifestData -Path $moduleManifestPath -Tags 'MacOS'
           }
 
-          if ($Windows) {
+          if ($windowsPassed) {
               Add-ModuleManifestData -Path $moduleManifestPath -Tags 'Windows'
           }
           Stop-LogGroup


### PR DESCRIPTION
## Description

- Fix an issue where tags and PS Version was not being set in manifest based on module test results.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
