### PR TITLE
🩹 [Patch]: Disable MARKDOWN/YAML_PRETTIER linter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -529,6 +529,8 @@ jobs:
           RUN_LOCAL: true
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_JSCPD: false
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false
 
   BuildSite:
     name: Build Site

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -28,3 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           VALIDATE_JSCPD: false
+          VALIDATE_MARKDOWN_PRETTIER: false

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -29,3 +29,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           VALIDATE_JSCPD: false
           VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -540,6 +540,7 @@ jobs:
           RUN_LOCAL: true
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_JSCPD: false
+          VALIDATE_MARKDOWN_PRETTIER: false
 
   PublishModule:
     name: Publish module

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -541,6 +541,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_JSCPD: false
           VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false
 
   PublishModule:
     name: Publish module


### PR DESCRIPTION
## Description

- Disable both MARKDOWN_PRETTIER and YAML_PRETTIER in super-linter, as format from platyPS is not compatible with the Markdown Prettier linter.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
