### PR TITLE
🩹 [Patch]: Don't evaluate GITLEAKS on documentation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -443,6 +443,7 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_YAML_PRETTIER: false
+          VALIDATE_GITLEAKS: false
 
   BuildSite:
     name: Build Site

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -454,6 +454,7 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_YAML_PRETTIER: false
+          VALIDATE_GITLEAKS: false
 
   PublishModule:
     name: Publish module


### PR DESCRIPTION
## Description

- GitLeaks makes it difficult to have actual examples on the documentation. Skipping it here.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
