### PR TITLE
🪲 [Fix]: Fix an issue where prereleases was not created during

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -597,7 +597,7 @@ jobs:
 
   PublishModule:
     name: Publish module
-    if: ${{ needs.TestModuleStatus.result == 'success' && !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.merged == true}}
+    if: ${{ needs.TestModuleStatus.result == 'success' && !cancelled() && github.event_name == 'pull_request' }}
     needs:
       - TestModuleStatus
       - BuildSite


### PR DESCRIPTION
## Description

- Reestablish functionality to run `Publish-PSModule` during PR. Used to create prereleases of a module before it is published with a release version. 
- Revert: #37. This should have been reverted in the following PR, seeing as it was for nightly runs/adhoc runs. The `CI.yml` template was added just after which rendered this change unnecessary.
  - It still remains to find a way to perserve the functionality, but not need a pipeline to do it. I.e. a prereleaser "chat" bot that takes commands from maintainers in the comments of the PR.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
