### PR TITLE
🩹 [Patch]: Upload artifacts are now included on `Build-PSModule`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -173,22 +173,6 @@ jobs:
           ModulesOutputPath: ${{ inputs.ModulesOutputPath }}
           DocsOutputPath: ${{ inputs.DocsOutputPath }}
 
-      - name: Upload module artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: module
-          path: ${{ inputs.ModulesOutputPath }}
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: docs
-          path: ${{ inputs.DocsOutputPath }}
-          if-no-files-found: error
-          retention-days: 1
-
   # This is necessary as there is no way to get output from a matrix job
   TestModule-pwsh-ubuntu-latest:
     name: Test module (pwsh, ubuntu-latest)

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -180,22 +180,6 @@ jobs:
           ModulesOutputPath: ${{ inputs.ModulesOutputPath }}
           DocsOutputPath: ${{ inputs.DocsOutputPath }}
 
-      - name: Upload module artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: module
-          path: ${{ inputs.ModulesOutputPath }}
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: docs
-          path: ${{ inputs.DocsOutputPath }}
-          if-no-files-found: error
-          retention-days: 1
-
   #This is necessary as there is no way to get output from a matrix job
   TestModule-pwsh-ubuntu-latest:
     name: Test module (pwsh, ubuntu-latest)


### PR DESCRIPTION
## Description

- Remove upload artifact from build job as it is now included on `Build-PSModule` action.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
