### PR TITLE
🩹 [Patch]: Add new personal access tokens for organization and user account

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,11 +12,14 @@ on:
       TEST_APP_PRIVATE_KEY:
         description: The private key for the test application
         required: false
-      TEST_FG_PAT:
-        description: The personal access token for the test application
+      TEST_FG_ORG_PAT:
+        description: The personal access token with access to the test organization
+        required: false
+      TEST_FG_USER_PAT:
+        description: The personal access token with access to the user account
         required: false
       TEST_PAT:
-        description: The personal access token for the test application
+        description: The personal access token for the test account
         required: false
     inputs:
       Name:
@@ -77,7 +80,8 @@ env:
   GITHUB_TOKEN: ${{ github.token }} # Used for GitHub CLI authentication
   TEST_APP_CLIENT_ID: ${{ secrets.TEST_APP_CLIENT_ID }}
   TEST_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
-  TEST_FG_PAT: ${{ secrets.TEST_FG_PAT }}
+  TEST_FG_ORG_PAT: ${{ secrets.TEST_FG_ORG_PAT }}
+  TEST_FG_USER_PAT: ${{ secrets.TEST_FG_USER_PAT }}
   TEST_PAT: ${{ secrets.TEST_PAT }}
 
 permissions:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,22 +4,22 @@ on:
   workflow_call:
     secrets:
       APIKey:
-        description: The API key to use when publishing modules
+        description: The API key for the PowerShell Gallery.
         required: true
       TEST_APP_CLIENT_ID:
-        description: The client ID for the test application
+        description: The client ID of an app for running tests.
         required: false
       TEST_APP_PRIVATE_KEY:
-        description: The private key for the test application
+        description: The private key of an app for running tests.
         required: false
       TEST_FG_ORG_PAT:
-        description: The personal access token with access to the test organization
+        description: The fine-grained personal access token with org access for running tests.
         required: false
       TEST_FG_USER_PAT:
-        description: The personal access token with access to the user account
+        description: The fine-grained personal access token with user account access for running tests.
         required: false
       TEST_PAT:
-        description: The personal access token for the test account
+        description: The classic personal access token for running tests.
         required: false
     inputs:
       Name:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,11 +12,14 @@ on:
       TEST_APP_PRIVATE_KEY:
         description: The private key for the test application
         required: false
-      TEST_FG_PAT:
-        description: The personal access token for the test application
+      TEST_FG_ORG_PAT:
+        description: The personal access token with access to the test organization
+        required: false
+      TEST_FG_USER_PAT:
+        description: The personal access token with access to the user account
         required: false
       TEST_PAT:
-        description: The personal access token for the test application
+        description: The personal access token for the test account
         required: false
     inputs:
       Name:
@@ -82,7 +85,8 @@ env:
   GITHUB_TOKEN: ${{ github.token }} # Used for GitHub CLI authentication
   TEST_APP_CLIENT_ID: ${{ secrets.TEST_APP_CLIENT_ID }}
   TEST_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
-  TEST_FG_PAT: ${{ secrets.TEST_FG_PAT }}
+  TEST_FG_ORG_PAT: ${{ secrets.TEST_FG_ORG_PAT }}
+  TEST_FG_USER_PAT: ${{ secrets.TEST_FG_USER_PAT }}
   TEST_PAT: ${{ secrets.TEST_PAT }}
 
 permissions:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,22 +4,22 @@ on:
   workflow_call:
     secrets:
       APIKey:
-        description: The API key to use when publishing modules
+        description: The API key for the PowerShell Gallery.
         required: true
       TEST_APP_CLIENT_ID:
-        description: The client ID for the test application
+        description: The client ID of an app for running tests.
         required: false
       TEST_APP_PRIVATE_KEY:
-        description: The private key for the test application
+        description: The private key of an app for running tests.
         required: false
       TEST_FG_ORG_PAT:
-        description: The personal access token with access to the test organization
+        description: The fine-grained personal access token with org access for running tests.
         required: false
       TEST_FG_USER_PAT:
-        description: The personal access token with access to the user account
+        description: The fine-grained personal access token with user account access for running tests.
         required: false
       TEST_PAT:
-        description: The personal access token for the test account
+        description: The classic personal access token for running tests.
         required: false
     inputs:
       Name:

--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ in the workflow file.
 | ---- | -------- | ----------- | ------- |
 | `GITHUB_TOKEN` | `github` context | The token used to authenticate with GitHub. | `${{ secrets.GITHUB_TOKEN }}` |
 | `APIKey` | GitHub secrets | The API key for the PowerShell Gallery. | N/A |
-| `TEST_APP_CLIENT_ID` | GitHub secrets | The client ID for running tests. | N/A |
-| `TEST_APP_PRIVATE_KEY` | GitHub secrets | The private key for running tests. | N/A |
-| `TEST_FG_PAT` | GitHub secrets | The fine-grained personal access token for running tests. | N/A |
+| `TEST_APP_CLIENT_ID` | GitHub secrets | The client ID of an app for running tests. | N/A |
+| `TEST_APP_PRIVATE_KEY` | GitHub secrets | The private key of an app for running tests. | N/A |
+| `TEST_FG_ORG_PAT` | GitHub secrets | The fine-grained personal access token with org access for running tests. | N/A |
+| `TEST_FG_USER_PAT` | GitHub secrets | The fine-grained personal access token with user account access for running tests. | N/A |
 | `TEST_PAT` | GitHub secrets | The classic personal access token for running tests. | N/A |
 
 ## Permissions

--- a/tests/tests/PSModuleTest.Tests.ps1
+++ b/tests/tests/PSModuleTest.Tests.ps1
@@ -8,7 +8,7 @@ Param(
 Write-Verbose "Path to the module: [$Path]" -Verbose
 
 Describe 'Environment Variables are available' {
-    It 'Should be available [<_>]' -ForEach @('TEST_APP_CLIENT_ID', 'TEST_APP_PRIVATE_KEY', 'TEST_FG_PAT', 'TEST_PAT') {
+    It 'Should be available [<_>]' -ForEach @('TEST_APP_CLIENT_ID', 'TEST_APP_PRIVATE_KEY', 'TEST_FG_ORG_PAT', 'TEST_FG_USER_PAT', 'TEST_PAT') {
         $name = $_
         Write-Verbose "Environment variable: [$name]" -Verbose
         Get-ChildItem env: | Where-Object { $_.Name -eq $name } | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
## Description

This pull request includes updates to the 'CI' and 'workflow' workflow config, environment variables, and documentation to allow it to handle two Fine-grained access tokens.

Updates to 'CI' and 'workflow' workflow configuration:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L7-R22): Updated descriptions for `APIKey`, `TEST_APP_CLIENT_ID`, `TEST_APP_PRIVATE_KEY`, and `TEST_PAT`. Added new secrets `TEST_FG_ORG_PAT` and `TEST_FG_USER_PAT` for fine-grained personal access tokens with org and user account access respectively.
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L80-R84): Updated environment variables to include `TEST_FG_ORG_PAT` and `TEST_FG_USER_PAT`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R97): Updated descriptions for `TEST_APP_CLIENT_ID`, `TEST_APP_PRIVATE_KEY`, `TEST_FG_ORG_PAT`, `TEST_FG_USER_PAT`, and `TEST_PAT` to reflect changes in the workflow configuration.

Test updates:

* [`tests/tests/PSModuleTest.Tests.ps1`](diffhunk://#diff-08780d45f860f48bf959e30a0dd51be9defa0a61999bac6d9f45822e97b701d8L11-R11): Updated the list of environment variables to include `TEST_FG_ORG_PAT` and `TEST_FG_USER_PAT`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
