### PR TITLE
🩹 [Patch]: Add new secrets that the 'CI' and 'workflow' can handle

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,19 +6,25 @@ on:
       APIKey:
         description: The API key for the PowerShell Gallery.
         required: true
-      TEST_APP_CLIENT_ID:
-        description: The client ID of an app for running tests.
+      TEST_APP_ENT_CLIENT_ID:
+        description: The client ID of an Enterprise GitHub App for running tests.
         required: false
-      TEST_APP_PRIVATE_KEY:
-        description: The private key of an app for running tests.
+      TEST_APP_ENT_PRIVATE_KEY:
+        description: The private key of an Enterprise GitHub App for running tests.
         required: false
-      TEST_FG_ORG_PAT:
+      TEST_APP_ORG_CLIENT_ID:
+        description: The client ID of an Organization GitHub App for running tests.
+        required: false
+      TEST_APP_ORG_PRIVATE_KEY:
+        description: The private key of an Organization GitHub App for running tests.
+        required: false
+      TEST_USER_ORG_FG_PAT:
         description: The fine-grained personal access token with org access for running tests.
         required: false
-      TEST_FG_USER_PAT:
+      TEST_USER_USER_FG_PAT:
         description: The fine-grained personal access token with user account access for running tests.
         required: false
-      TEST_PAT:
+      TEST_USER_PAT:
         description: The classic personal access token for running tests.
         required: false
     inputs:
@@ -78,11 +84,13 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ github.token }} # Used for GitHub CLI authentication
-  TEST_APP_CLIENT_ID: ${{ secrets.TEST_APP_CLIENT_ID }}
-  TEST_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
-  TEST_FG_ORG_PAT: ${{ secrets.TEST_FG_ORG_PAT }}
-  TEST_FG_USER_PAT: ${{ secrets.TEST_FG_USER_PAT }}
-  TEST_PAT: ${{ secrets.TEST_PAT }}
+  TEST_APP_ENT_CLIENT_ID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
+  TEST_APP_ENT_PRIVATE_KEY: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
+  TEST_APP_ORG_CLIENT_ID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
+  TEST_APP_ORG_PRIVATE_KEY: ${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}
+  TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
+  TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
+  TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
 
 permissions:
   contents: read       # to checkout the repository

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,19 +6,25 @@ on:
       APIKey:
         description: The API key for the PowerShell Gallery.
         required: true
-      TEST_APP_CLIENT_ID:
-        description: The client ID of an app for running tests.
+      TEST_APP_ENT_CLIENT_ID:
+        description: The client ID of an Enterprise GitHub App for running tests.
         required: false
-      TEST_APP_PRIVATE_KEY:
-        description: The private key of an app for running tests.
+      TEST_APP_ENT_PRIVATE_KEY:
+        description: The private key of an Enterprise GitHub App for running tests.
         required: false
-      TEST_FG_ORG_PAT:
+      TEST_APP_ORG_CLIENT_ID:
+        description: The client ID of an Organization GitHub App for running tests.
+        required: false
+      TEST_APP_ORG_PRIVATE_KEY:
+        description: The private key of an Organization GitHub App for running tests.
+        required: false
+      TEST_USER_ORG_FG_PAT:
         description: The fine-grained personal access token with org access for running tests.
         required: false
-      TEST_FG_USER_PAT:
+      TEST_USER_USER_FG_PAT:
         description: The fine-grained personal access token with user account access for running tests.
         required: false
-      TEST_PAT:
+      TEST_USER_PAT:
         description: The classic personal access token for running tests.
         required: false
     inputs:
@@ -83,11 +89,13 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ github.token }} # Used for GitHub CLI authentication
-  TEST_APP_CLIENT_ID: ${{ secrets.TEST_APP_CLIENT_ID }}
-  TEST_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
-  TEST_FG_ORG_PAT: ${{ secrets.TEST_FG_ORG_PAT }}
-  TEST_FG_USER_PAT: ${{ secrets.TEST_FG_USER_PAT }}
-  TEST_PAT: ${{ secrets.TEST_PAT }}
+  TEST_APP_ENT_CLIENT_ID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
+  TEST_APP_ENT_PRIVATE_KEY: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
+  TEST_APP_ORG_CLIENT_ID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
+  TEST_APP_ORG_PRIVATE_KEY: ${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}
+  TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
+  TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
+  TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
 
 permissions:
   contents: write      # to checkout the repo and create releases on the repo

--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ in the workflow file.
 | ---- | -------- | ----------- | ------- |
 | `GITHUB_TOKEN` | `github` context | The token used to authenticate with GitHub. | `${{ secrets.GITHUB_TOKEN }}` |
 | `APIKey` | GitHub secrets | The API key for the PowerShell Gallery. | N/A |
-| `TEST_APP_CLIENT_ID` | GitHub secrets | The client ID of an app for running tests. | N/A |
-| `TEST_APP_PRIVATE_KEY` | GitHub secrets | The private key of an app for running tests. | N/A |
-| `TEST_FG_ORG_PAT` | GitHub secrets | The fine-grained personal access token with org access for running tests. | N/A |
-| `TEST_FG_USER_PAT` | GitHub secrets | The fine-grained personal access token with user account access for running tests. | N/A |
-| `TEST_PAT` | GitHub secrets | The classic personal access token for running tests. | N/A |
+| `TEST_APP_ENT_CLIENT_ID` | GitHub secrets | The client ID of an Enterprise GitHub App for running tests. | N/A |
+| `TEST_APP_ENT_PRIVATE_KEY` | GitHub secrets | The private key of an Enterprise GitHub App for running tests. | N/A |
+| `TEST_APP_ORG_CLIENT_ID` | GitHub secrets | The client ID of an Organization GitHub App for running tests. | N/A |
+| `TEST_APP_ORG_PRIVATE_KEY` | GitHub secrets | The private key of an Organization GitHub App for running tests. | N/A |
+| `TEST_USER_ORG_FG_PAT` | GitHub secrets | The fine-grained personal access token with org access for running tests. | N/A |
+| `TEST_USER_USER_FG_PAT` | GitHub secrets | The fine-grained personal access token with user account access for running tests. | N/A |
+| `TEST_USER_PAT` | GitHub secrets | The classic personal access token for running tests. | N/A |
 
 ## Permissions
 

--- a/tests/tests/PSModuleTest.Tests.ps1
+++ b/tests/tests/PSModuleTest.Tests.ps1
@@ -6,9 +6,16 @@ Param(
 )
 
 Write-Verbose "Path to the module: [$Path]" -Verbose
-
 Describe 'Environment Variables are available' {
-    It 'Should be available [<_>]' -ForEach @('TEST_APP_CLIENT_ID', 'TEST_APP_PRIVATE_KEY', 'TEST_FG_ORG_PAT', 'TEST_FG_USER_PAT', 'TEST_PAT') {
+    It 'Should be available [<_>]' -ForEach @(
+        'TEST_APP_ENT_CLIENT_ID',
+        'TEST_APP_ENT_PRIVATE_KEY',
+        'TEST_APP_ORG_CLIENT_ID',
+        'TEST_APP_ORG_PRIVATE_KEY',
+        'TEST_USER_ORG_FG_PAT',
+        'TEST_USER_USER_FG_PAT',
+        'TEST_USER_PAT'
+    ) {
         $name = $_
         Write-Verbose "Environment variable: [$name]" -Verbose
         Get-ChildItem env: | Where-Object { $_.Name -eq $name } | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
## Description

This pull request includes updates to the environment variables used in the GitHub Actions workflows and corresponding documentation. The changes primarily involve renaming and adding new environment variables for different types of GitHub Apps and tokens.

### Updates to environment variables:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L9-R27): Renamed and added new environment variables for Enterprise and Organization GitHub Apps, as well as fine-grained personal access tokens. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L9-R27) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L81-R93)
* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L9-R27): Made similar updates to environment variables for GitHub Apps and tokens as in `CI.yml`. [[1]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L9-R27) [[2]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L86-R98)

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R100): Updated the list of environment variables to reflect the new names and additions for GitHub Apps and tokens.

### Test updates:

* [`tests/tests/PSModuleTest.Tests.ps1`](diffhunk://#diff-08780d45f860f48bf959e30a0dd51be9defa0a61999bac6d9f45822e97b701d8L9-R18): Updated the test script to check for the availability of the new environment variables.
## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
