### PR TITLE
🩹 [Patch]: Disable `JSON_PRETTIER` linting

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -545,6 +545,7 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_YAML_PRETTIER: false
+          VALIDATE_JSON_PRETTIER: false
           VALIDATE_GITLEAKS: false
 
   BuildSite:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -210,7 +210,7 @@ jobs:
           Version: ${{ inputs.Version }}
 
       - name: Build module
-        uses: PSModule/Build-PSModule@overrides
+        uses: PSModule/Build-PSModule@v2
         with:
           Name: ${{ inputs.Name }}
           Path: ${{ inputs.Path }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -210,7 +210,7 @@ jobs:
           Version: ${{ inputs.Version }}
 
       - name: Build module
-        uses: PSModule/Build-PSModule@v2
+        uses: PSModule/Build-PSModule@overrides
         with:
           Name: ${{ inputs.Name }}
           Path: ${{ inputs.Path }}


### PR DESCRIPTION
## Description

This pull request a validation setting to disable 'JSON Prettier' validation by setting `VALIDATE_JSON_PRETTIER: false`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
