### PR TITLE
🩹 [Patch]: Add `PSModule/Debug` steps when `Debug: true`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,6 +106,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -134,6 +138,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -161,6 +169,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
@@ -194,6 +206,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -225,6 +241,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
@@ -274,6 +294,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -321,6 +345,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
@@ -370,6 +398,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
@@ -491,6 +523,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Download docs artifact
         uses: actions/download-artifact@v4
         with:
@@ -530,6 +566,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -315,6 +315,8 @@ jobs:
       - name: Test built module
         id: test
         uses: PSModule/Test-PSModule@v2
+        env:
+          DYLD_PRINT_LIBRARIES: ${{ inputs.Debug }}
         continue-on-error: true
         with:
           Name: ${{ inputs.Name }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -298,6 +298,8 @@ jobs:
       - name: Test built module
         id: test
         uses: PSModule/Test-PSModule@v2
+        env:
+          DYLD_PRINT_LIBRARIES: 1
         continue-on-error: true
         with:
           Name: ${{ inputs.Name }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -616,9 +616,6 @@ jobs:
           name: docs
           path: '${{ inputs.SiteOutputPath }}/docs/Functions'
 
-      - name: Debug
-        uses: PSModule/Debug@v0
-
       - uses: actions/configure-pages@v5
 
       - name: Install mkdoks-material

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -323,7 +323,7 @@ jobs:
         id: test
         uses: PSModule/Test-PSModule@v2
         env:
-          DYLD_PRINT_LIBRARIES: 1
+          DYLD_PRINT_LIBRARIES: ${{ inputs.Debug }}
         continue-on-error: true
         with:
           Name: ${{ inputs.Name }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -113,6 +113,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -141,6 +145,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -168,6 +176,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
@@ -201,6 +213,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -232,6 +248,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
@@ -280,6 +300,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
@@ -331,6 +355,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -379,6 +407,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
@@ -513,6 +545,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -561,6 +597,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
@@ -674,6 +714,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@v1
         with:
@@ -714,6 +758,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      - name: Debug
+        if: ${{ inputs.Debug }}
+        uses: PSModule/Debug@v0
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
 | `TestProcess` | `boolean` | Whether to test the process. | `false` | `false` |
 | `Version` | `string` | Specifies the version of the GitHub module to be installed. The value must be an exact version. | `false` | N/A |
 | `Prerelease` | `boolean` | Whether to use a prerelease version of the 'GitHub' module. | `false` | `false` |
-| `Debug` | `boolean` | Whether to enable debug output. | `false` | `false` |
+| `Debug` | `boolean` | Whether to enable debug output. Adds a `debug` step to every job. | `false` | `false` |
 | `Verbose` | `boolean` | Whether to enable verbose output. | `false` | `false` |
 
 ### Secrets


### PR DESCRIPTION
## Description

This pull request introduces several changes to the GitHub Actions workflows to add a debug step to every job if the `Debug` input is enabled. It also updates the `README.md` to reflect this change. Below are the most important changes:

### Workflow Updates:

* Added a `Debug` step to multiple jobs in the `.github/workflows/CI.yml` file, which uses the `PSModule/Debug@v0` action and is conditional on the `Debug` input. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R109-R112) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R141-R144) [[3]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R173-R176) [[4]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R209-R212) [[5]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R245-R248) [[6]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R297-R300) [[7]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R351-R354) [[8]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R404-R407) [[9]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R528-R531) [[10]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R572-R575)

* Added a `Debug` step to multiple jobs in the `.github/workflows/workflow.yml` file, which uses the `PSModule/Debug@v0` action and is conditional on the `Debug` input. [[1]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R116-R119) [[2]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R148-R151) [[3]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R180-R183) [[4]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R216-R219) [[5]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R252-R255) [[6]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R304-R307) [[7]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R358-R361) [[8]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R411-R414) [[9]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R548-R551) [[10]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R601-R604) [[11]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R714-R717) [[12]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R758-R761)

* Updated the `Test built module` step in both `.github/workflows/CI.yml` and `.github/workflows/workflow.yml` to include `DYLD_PRINT_LIBRARIES` environment variable if `Debug` input is enabled. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R318-R319) [[2]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R325-R326)

### Documentation Update:

* Updated the `README.md` file to clarify that enabling the `Debug` input adds a `debug` step to every job.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
