### PR TITLE
🩹 [Patch]: Remove unused `DYLD_PRINT_LIBRARIES` environment variable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -315,8 +315,6 @@ jobs:
       - name: Test built module
         id: test
         uses: PSModule/Test-PSModule@v2
-        env:
-          DYLD_PRINT_LIBRARIES: ${{ inputs.Debug }}
         continue-on-error: true
         with:
           Name: ${{ inputs.Name }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -322,8 +322,6 @@ jobs:
       - name: Test built module
         id: test
         uses: PSModule/Test-PSModule@v2
-        env:
-          DYLD_PRINT_LIBRARIES: ${{ inputs.Debug }}
         continue-on-error: true
         with:
           Name: ${{ inputs.Name }}


### PR DESCRIPTION
## Description

This pull request includes changes to two GitHub workflow files, specifically removing an environment variable setup for testing modules. The most important changes are:

GitHub workflow updates:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L318-L319): Removed the `env` section that set `DYLD_PRINT_LIBRARIES` to `${{ inputs.Debug }}` in the `Test built module` job.
* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L325-L326): Removed the `env` section that set `DYLD_PRINT_LIBRARIES` to `${{ inputs.Debug }}` in the `Test built module` job.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
