### PR TITLE
🪲 [Fix]: Fix an issue that break the workflow when there is nothing to commit in `BuildDocs` 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -261,9 +261,16 @@ jobs:
 
       - name: Commit all changes
         continue-on-error: true
+        shell: pwsh
         run: |
+          # Rename the gitignore file to .gitignore.bak
+          Rename-Item -Path '.gitignore' -NewName '.gitignore.bak' -Force
+
           git add .
           git commit -m 'Update documentation'
+
+          # Restore the gitignore file
+          Rename-Item -Path '.gitignore.bak' -NewName '.gitignore' -Force
 
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -259,6 +259,12 @@ jobs:
           Verbose: ${{ inputs.Verbose }}
           Version: ${{ inputs.Version }}
 
+      - name: Commit all changes
+        continue-on-error: true
+        run: |
+          git add .
+          git commit -m 'Update documentation'
+
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -259,11 +259,6 @@ jobs:
           Verbose: ${{ inputs.Verbose }}
           Version: ${{ inputs.Version }}
 
-      - name: Commit all changes
-        run: |
-          git add .
-          git commit -m 'Update documentation'
-
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest
         env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -268,9 +268,16 @@ jobs:
 
       - name: Commit all changes
         continue-on-error: true
+        shell: pwsh
         run: |
+          # Rename the gitignore file to .gitignore.bak
+          Rename-Item -Path '.gitignore' -NewName '.gitignore.bak' -Force
+
           git add .
           git commit -m 'Update documentation'
+
+          # Restore the gitignore file
+          Rename-Item -Path '.gitignore.bak' -NewName '.gitignore' -Force
 
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -266,11 +266,6 @@ jobs:
           Verbose: ${{ inputs.Verbose }}
           Version: ${{ inputs.Version }}
 
-      - name: Commit all changes
-        run: |
-          git add .
-          git commit -m 'Update documentation'
-
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest
         env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -266,6 +266,12 @@ jobs:
           Verbose: ${{ inputs.Verbose }}
           Version: ${{ inputs.Version }}
 
+      - name: Commit all changes
+        continue-on-error: true
+        run: |
+          git add .
+          git commit -m 'Update documentation'
+
       - name: Lint documentation
         uses: super-linter/super-linter/slim@latest
         env:

--- a/tests/srcTestRepo/src/functions/public/Test-PSModuleTest.ps1
+++ b/tests/srcTestRepo/src/functions/public/Test-PSModuleTest.ps1
@@ -1,7 +1,7 @@
 ﻿function Test-PSModuleTest {
     <#
         .SYNOPSIS
-        Performs tests on a module.
+        Performs tests on a module. Api, url, and file name.
 
         .EXAMPLE
         Test-PSModule -Name 'World'

--- a/tests/srcTestRepo/src/functions/public/Test-PSModuleTest.ps1
+++ b/tests/srcTestRepo/src/functions/public/Test-PSModuleTest.ps1
@@ -1,7 +1,7 @@
 ﻿function Test-PSModuleTest {
     <#
         .SYNOPSIS
-        Performs tests on a module. Api, url, and file name.
+        Performs tests on a module.
 
         .EXAMPLE
         Test-PSModule -Name 'World'

--- a/tests/srcTestRepo/src/functions/public/completers.ps1
+++ b/tests/srcTestRepo/src/functions/public/completers.ps1
@@ -1,0 +1,8 @@
+﻿Register-ArgumentCompleter -CommandName New-PSModuleTest -ParameterName Name -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters
+
+    'Alice', 'Bob', 'Charlie' | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+    }
+}

--- a/tests/srcWithManifestTestRepo/src/functions/public/Test-PSModuleTest.ps1
+++ b/tests/srcWithManifestTestRepo/src/functions/public/Test-PSModuleTest.ps1
@@ -1,7 +1,7 @@
 ﻿function Test-PSModuleTest {
     <#
         .SYNOPSIS
-        Performs tests on a module. Api, url, and file name.
+        Performs tests on a module.
 
         .EXAMPLE
         Test-PSModule -Name 'World'

--- a/tests/srcWithManifestTestRepo/src/functions/public/Test-PSModuleTest.ps1
+++ b/tests/srcWithManifestTestRepo/src/functions/public/Test-PSModuleTest.ps1
@@ -1,8 +1,7 @@
-﻿#SkipTest:Verbose:Just want to test that a function can have multiple skips.
-function Test-PSModuleTest {
+﻿function Test-PSModuleTest {
     <#
         .SYNOPSIS
-        Performs tests on a module.
+        Performs tests on a module. Api, url, and file name.
 
         .EXAMPLE
         Test-PSModule -Name 'World'
@@ -16,5 +15,4 @@ function Test-PSModuleTest {
         [string] $Name
     )
     Write-Output "Hello, $Name!"
-    Write-Verbose 'Verbose message' -Verbose
 }


### PR DESCRIPTION
## Description

This pull request updates the reusable workflow files to handle docs generation without errors.

Improvements to reusable workflows (CI.yml and workflow.yml) :

* In "BuildDocs":
  * Added `continue-on-error: true` and changed the shell to `pwsh` for the "Commit all changes" step. Also added commands to temporarily rename the `.gitignore` file during the commit process.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
