### PR TITLE
🪲 [Fix]: Fix placement of docs after copy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -307,7 +307,7 @@ jobs:
           Version: ${{ inputs.Version }}
           Script: |
             New-Item -Path "$env:GITHUB_WORKSPACE/${{ inputs.SiteOutputPath }}/docs/Functions" -ItemType Directory -Force
-            Copy-Item -Path "$env:GITHUB_WORKSPACE/${{ inputs.DocsOutputPath }}" -Destination "$env:GITHUB_WORKSPACE/${{ inputs.SiteOutputPath }}/docs/Functions" -Recurse -Force
+            Copy-Item -Path "$env:GITHUB_WORKSPACE/${{ inputs.DocsOutputPath }}/*" -Destination "$env:GITHUB_WORKSPACE/${{ inputs.SiteOutputPath }}/docs/Functions" -Recurse -Force
             $moduleName = [string]::IsNullOrEmpty('${{ inputs.Name }}') ? $env:GITHUB_REPOSITORY_NAME : '${{ inputs.Name }}'
             $ModuleSourcePath = Join-Path $PWD -ChildPath '${{ inputs.Path }}'
             $SiteOutputPath = Join-Path $PWD -ChildPath '${{ inputs.SiteOutputPath }}'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -266,8 +266,13 @@ jobs:
           # Rename the gitignore file to .gitignore.bak
           Rename-Item -Path '.gitignore' -NewName '.gitignore.bak' -Force
 
-          git add .
-          git commit -m 'Update documentation'
+          try {
+              # Add all changes to the repository
+              git add .
+              git commit -m 'Update documentation'
+          } catch {
+              Write-Host "No changes to commit"
+          }
 
           # Restore the gitignore file
           Rename-Item -Path '.gitignore.bak' -NewName '.gitignore' -Force

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -273,8 +273,13 @@ jobs:
           # Rename the gitignore file to .gitignore.bak
           Rename-Item -Path '.gitignore' -NewName '.gitignore.bak' -Force
 
-          git add .
-          git commit -m 'Update documentation'
+          try {
+              # Add all changes to the repository
+              git add .
+              git commit -m 'Update documentation'
+          } catch {
+              Write-Host "No changes to commit"
+          }
 
           # Restore the gitignore file
           Rename-Item -Path '.gitignore.bak' -NewName '.gitignore' -Force
@@ -314,20 +319,19 @@ jobs:
           Version: ${{ inputs.Version }}
           Script: |
             New-Item -Path "$env:GITHUB_WORKSPACE/${{ inputs.SiteOutputPath }}/docs/Functions" -ItemType Directory -Force
-            Copy-Item -Path "$env:GITHUB_WORKSPACE/${{ inputs.DocsOutputPath }}" -Destination "$env:GITHUB_WORKSPACE/${{ inputs.SiteOutputPath }}/docs/Functions" -Recurse -Force
+            Copy-Item -Path "$env:GITHUB_WORKSPACE/${{ inputs.DocsOutputPath }}/*" -Destination "$env:GITHUB_WORKSPACE/${{ inputs.SiteOutputPath }}/docs/Functions" -Recurse -Force
             $moduleName = [string]::IsNullOrEmpty('${{ inputs.Name }}') ? $env:GITHUB_REPOSITORY_NAME : '${{ inputs.Name }}'
             $ModuleSourcePath = Join-Path $PWD -ChildPath '${{ inputs.Path }}'
             $SiteOutputPath = Join-Path $PWD -ChildPath '${{ inputs.SiteOutputPath }}'
 
-            LogGroup "Get folderstructure" {
-                Get-ChildItem -Recurse | Select-Object -ExpandProperty FullName | Sort-Object
+            LogGroup "Get folder structure" {
+                Get-ChildItem -Recurse | Select-Object -ExpandProperty FullName | Sort-Object | Format-List
             }
 
             $functionDocsFolder = Join-Path -Path $SiteOutputPath -ChildPath 'docs/Functions' | Get-Item
             Get-ChildItem -Path $functionDocsFolder -Recurse -Force -Include '*.md' | ForEach-Object {
                 $fileName = $_.Name
-                $hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash
-                LogGroup " - [$fileName] - [$hash]" {
+                LogGroup " - $fileName" {
                     Show-FileContent -Path $_
                 }
             }


### PR DESCRIPTION
## Description

This pull request includes improvements to the `CI.yml` and `workflow.yml` reusable workflows. 

* Modified the `Copy-Item` command to include all files in the source directory by appending `/*` to the path.
* Added a `try-catch` block around the `git add` and `git commit` commands to handle cases where there are no changes to commit, preventing errors.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
