### PR TITLE
🪲 [Fix]: Restore use of `GITHUB_TOKEN` and `Prescript` on module tests

### DIFF
--- a/.github/workflows/Test-ModuleLocal.yml
+++ b/.github/workflows/Test-ModuleLocal.yml
@@ -114,7 +114,7 @@ jobs:
           TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
           TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
           TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }} # Used in tests!
         with:
           Debug: ${{ inputs.Debug }}
           Prerelease: ${{ inputs.Prerelease }}

--- a/.github/workflows/Test-ModuleLocal.yml
+++ b/.github/workflows/Test-ModuleLocal.yml
@@ -130,3 +130,5 @@ jobs:
           Path: ${{ inputs.TestPath }}
           Run_Path: ${{ steps.import-module.outputs.path }}
           WorkingDirectory: ${{ inputs.WorkingDirectory }}
+          Prescript: | # This is to speed up module loading in Pester.
+            Import-Module -Name '${{ steps.import-module.outputs.name }}' -RequiredVersion 999.0.0

--- a/.github/workflows/Test-ModuleLocal.yml
+++ b/.github/workflows/Test-ModuleLocal.yml
@@ -114,6 +114,7 @@ jobs:
           TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
           TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
           TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           Debug: ${{ inputs.Debug }}
           Prerelease: ${{ inputs.Prerelease }}


### PR DESCRIPTION
## Description

This pull request reverts changes to the `.github/workflows/Test-ModuleLocal.yml` file to restore testing capabilities and module loading performance.

Details:

* Restored the `GITHUB_TOKEN` environment variable mapping, allowing it to be used in tests once more.
* Restored the `Prescript` step to preload the module with a specific version, optimizing module loading during Pester tests.
