### PR TITLE
🪲 [Fix]: Update PSResourceGet to latest during `Publish-PSModule`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -290,7 +290,7 @@ jobs:
       - name: Update PSResourceGet
         shell: pwsh
         run: |
-          Update-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
+          Update-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository -Scope AllUsers
 
       - name: Publish module
         uses: PSModule/Publish-PSModule@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -290,7 +290,8 @@ jobs:
       - name: Update PSResourceGet
         shell: pwsh
         run: |
-          Update-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository -Scope AllUsers
+          Get-Module -ListAvailable
+          Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository -Scope AllUsers
 
       - name: Publish module
         uses: PSModule/Publish-PSModule@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -287,10 +287,9 @@ jobs:
           name: module
           path: ${{ inputs.WorkingDirectory }}/outputs/module
 
-      - name: Update PSResourceGet
+      - name: Update Microsoft.PowerShell.PSResourceGet
         shell: pwsh
         run: |
-          Get-Module -ListAvailable
           Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
       - name: Publish module

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -291,7 +291,7 @@ jobs:
         shell: pwsh
         run: |
           Get-Module -ListAvailable
-          Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository -Scope AllUsers
+          Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
       - name: Publish module
         uses: PSModule/Publish-PSModule@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -287,6 +287,11 @@ jobs:
           name: module
           path: ${{ inputs.WorkingDirectory }}/outputs/module
 
+      - name: Update PSResourceGet
+        shell: pwsh
+        run: |
+          Update-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
+
       - name: Publish module
         uses: PSModule/Publish-PSModule@v2
         with:


### PR DESCRIPTION
## Description

This pull request introduces a small but important update to the GitHub Actions workflow configuration. It ensures that the latest version of the `Microsoft.PowerShell.PSResourceGet` module is installed before publishing a PowerShell module.

- Fixes https://github.com/PSModule/NerdFonts/issues/33

* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R290-R294): Added a step to install the `Microsoft.PowerShell.PSResourceGet` module from the PSGallery repository using `Install-PSResource`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
