### PR TITLE
🩹 [Patch]: Remove redundant actions

### DIFF
--- a/.github/workflows/Build-Module.yml
+++ b/.github/workflows/Build-Module.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build module
-        uses: PSModule/Build-PSModule@removeInit
+        uses: PSModule/Build-PSModule@v4
         with:
           Name: ${{ inputs.Name }}
           Debug: ${{ inputs.Debug }}

--- a/.github/workflows/Build-Module.yml
+++ b/.github/workflows/Build-Module.yml
@@ -44,15 +44,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Initialize environment
-        uses: PSModule/Initialize-PSModule@v1
-        with:
-          Debug: ${{ inputs.Debug }}
-          Prerelease: ${{ inputs.Prerelease }}
-          Verbose: ${{ inputs.Verbose }}
-          Version: ${{ inputs.Version }}
-          WorkingDirectory: ${{ inputs.WorkingDirectory }}
-
       - name: Build module
         uses: PSModule/Build-PSModule@v4
         with:

--- a/.github/workflows/Build-Module.yml
+++ b/.github/workflows/Build-Module.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build module
-        uses: PSModule/Build-PSModule@v4
+        uses: PSModule/Build-PSModule@removeInit
         with:
           Name: ${{ inputs.Name }}
           Debug: ${{ inputs.Debug }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -285,7 +285,7 @@ jobs:
           Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
       - name: Publish module
-        uses: PSModule/Publish-PSModule@v2
+        uses: PSModule/Publish-PSModule@removeInit
         with:
           Name: ${{ fromJson(needs.Get-Settings.outputs.Settings).Name }}
           ModulePath: ${{ inputs.WorkingDirectory }}/outputs/module

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -273,14 +273,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Initialize environment
-        uses: PSModule/Initialize-PSModule@v1
-        with:
-          Debug: ${{ inputs.Debug }}
-          Prerelease: ${{ inputs.Prerelease }}
-          Verbose: ${{ inputs.Verbose }}
-          Version: ${{ inputs.Version }}
-
       - name: Download module artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -285,7 +285,7 @@ jobs:
           Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
       - name: Publish module
-        uses: PSModule/Publish-PSModule@removeInit
+        uses: PSModule/Publish-PSModule@v2
         with:
           Name: ${{ fromJson(needs.Get-Settings.outputs.Settings).Name }}
           ModulePath: ${{ inputs.WorkingDirectory }}/outputs/module

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Process-PSModule
 
-
 A workflow for crafting PowerShell modules using the PSModule framework, which builds, tests and publishes PowerShell modules to the PowerShell
 Gallery and produces documentation that is published to GitHub Pages. The workflow is used by all PowerShell modules in the PSModule organization.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Process-PSModule
 
+
 A workflow for crafting PowerShell modules using the PSModule framework, which builds, tests and publishes PowerShell modules to the PowerShell
 Gallery and produces documentation that is published to GitHub Pages. The workflow is used by all PowerShell modules in the PSModule organization.
 


### PR DESCRIPTION
## Description

This pull request simplifies the workflow configuration by removing the `Initialize-PSModule` step from two GitHub Actions workflows. This change reduces redundancy and streamlines the build and artifact download processes.

Workflow updates:

* [`.github/workflows/Build-Module.yml`](diffhunk://#diff-288da0616802a69b7e5aa63f771fe1525eda2ec5b576e26423f28380b2e68833L47-L55): Removed the `Initialize-PSModule` step, which previously set up the environment for building the module.
* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L276-L283): Removed the `Initialize-PSModule` step, which was used to prepare the environment before downloading module artifacts.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
