### PR TITLE
🪲 [Fix]: Fix issue with parameters and GitHub token access

### DIFF
--- a/.github/workflows/Build-Module.yml
+++ b/.github/workflows/Build-Module.yml
@@ -40,6 +40,8 @@ jobs:
   Build-Module:
     name: Build-Module
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -48,8 +50,4 @@ jobs:
         uses: PSModule/Build-PSModule@v4
         with:
           Name: ${{ inputs.Name }}
-          Debug: ${{ inputs.Debug }}
-          Prerelease: ${{ inputs.Prerelease }}
-          Verbose: ${{ inputs.Verbose }}
-          Version: ${{ inputs.Version }}
           WorkingDirectory: ${{ inputs.WorkingDirectory }}

--- a/.github/workflows/Build-Module.yml
+++ b/.github/workflows/Build-Module.yml
@@ -7,26 +7,11 @@ on:
         type: string
         description: The name of the module to process. Scripts default to the repository name if nothing is specified.
         required: false
-      Debug:
-        type: boolean
-        description: Enable debug output.
-        required: false
-        default: false
-      Verbose:
-        type: boolean
-        description: Enable verbose output.
-        required: false
-        default: false
-      Version:
+      ArtifactName:
         type: string
-        description: Specifies the version of the GitHub module to be installed. The value must be an exact version.
+        description: Name of the artifact to upload.
         required: false
-        default: ''
-      Prerelease:
-        type: boolean
-        description: Whether to use a prerelease version of the 'GitHub' module.
-        required: false
-        default: false
+        default: module
       WorkingDirectory:
         type: string
         description: The working directory where the script will run from.
@@ -50,4 +35,5 @@ jobs:
         uses: PSModule/Build-PSModule@v4
         with:
           Name: ${{ inputs.Name }}
+          ArtifactName: ${{ inputs.ArtifactName }}
           WorkingDirectory: ${{ inputs.WorkingDirectory }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,10 +87,6 @@ jobs:
       - Get-Settings
     with:
       Name: ${{ fromJson(needs.Get-Settings.outputs.Settings).Name }}
-      Debug: ${{ inputs.Debug }}
-      Prerelease: ${{ inputs.Prerelease }}
-      Verbose: ${{ inputs.Verbose }}
-      Version: ${{ inputs.Version }}
       WorkingDirectory: ${{ inputs.WorkingDirectory }}
 
   Build-Docs:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -89,10 +89,6 @@ jobs:
       - Get-Settings
     with:
       Name: ${{ fromJson(needs.Get-Settings.outputs.Settings).Name }}
-      Debug: ${{ inputs.Debug }}
-      Prerelease: ${{ inputs.Prerelease }}
-      Verbose: ${{ inputs.Verbose }}
-      Version: ${{ inputs.Version }}
       WorkingDirectory: ${{ inputs.WorkingDirectory }}
 
   Build-Docs:


### PR DESCRIPTION
## Description

This pull request updates several GitHub Actions workflows to simplify input parameters and improve artifact handling. Key changes include the removal of unused parameters (`Debug`, `Verbose`, `Version`, and `Prerelease`) and the addition of an `ArtifactName` parameter for uploading artifacts. Additionally, environment variables are introduced for authentication.

### Simplification of input parameters:
* [`.github/workflows/Build-Module.yml`](diffhunk://#diff-288da0616802a69b7e5aa63f771fe1525eda2ec5b576e26423f28380b2e68833L10-R14): Removed unused parameters (`Debug`, `Verbose`, `Version`, and `Prerelease`) and added a new `ArtifactName` parameter to specify the name of the artifact to upload. [[1]](diffhunk://#diff-288da0616802a69b7e5aa63f771fe1525eda2ec5b576e26423f28380b2e68833L10-R14) [[2]](diffhunk://#diff-288da0616802a69b7e5aa63f771fe1525eda2ec5b576e26423f28380b2e68833L51-R38)

### Environment variable addition:
* [`.github/workflows/Build-Module.yml`](diffhunk://#diff-288da0616802a69b7e5aa63f771fe1525eda2ec5b576e26423f28380b2e68833R28-R29): Added the `GH_TOKEN` environment variable for authentication using GitHub's token.

### Consistency across workflows:
* `.github/workflows/CI.yml` and `.github/workflows/workflow.yml`: Removed references to unused parameters (`Debug`, `Verbose`, `Version`, and `Prerelease`) to align with the updated `Build-Module.yml`. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L90-L93) [[2]](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L92-L95)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
