### PR TITLE
Updating some div stuff with specify

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,4 +26,27 @@ PowerShell 7.4+ (GitHub Actions composite actions): Follow standard conventions
 - 001-building-on-this: Added PowerShell 7.4+ (GitHub Actions composite actions) + PSModule/GitHub-Script@v1, PSModule/Install-PSModuleHelpers@v1
 
 <!-- MANUAL ADDITIONS START -->
+
+## Terminal Commands
+
+When executing terminal commands (using `run_in_terminal` or similar tools):
+- **ALWAYS** prefix shell commands with `pwsh` unless it's a GitHub MCP call
+- This applies to all PowerShell scripts, git commands, and other shell operations
+- Exception: GitHub MCP Server calls should use their native format without `pwsh` prefix
+
+Examples:
+```bash
+# Correct - PowerShell script
+pwsh -Command "& './.specify/scripts/powershell/setup-plan.ps1' -Json"
+
+# Correct - Git command
+pwsh -Command "git status"
+
+# Correct - Any shell command
+pwsh -Command "ls -Recurse"
+
+# Exception - GitHub MCP calls (no pwsh prefix)
+gh issue create --title "Feature" --body "Description"
+```
+
 <!-- MANUAL ADDITIONS END -->

--- a/.github/instructions/md.instructions.md
+++ b/.github/instructions/md.instructions.md
@@ -163,6 +163,32 @@ Using list when table is better:
 - Feature C: Partial - Beta feature
 ```
 
+## Requirement Number Formatting
+
+When writing or referencing requirement numbers (NFR and FR) in documentation:
+- **Always use bold formatting** for requirement numbers
+- **Replace hyphens with non-breaking hyphens** (`&#8209;`) between letters and numbers
+- This prevents line breaks within requirement numbers and ensures consistent formatting
+- This applies to all specification documents, plans, and tables
+
+Examples:
+```markdown
+# Correct formatting
+**NFR&#8209;001**: The system must respond within 200ms
+**FR&#8209;042**: User authentication shall support OAuth 2.0
+
+# In tables
+| ID | Description |
+|----|-------------|
+| **NFR&#8209;001** | Performance requirement |
+| **FR&#8209;042** | Authentication feature |
+
+# Incorrect formatting (do not use)
+NFR-001: Without bold or non-breaking hyphen
+**NFR-001**: Bold but with regular hyphen (can break across lines)
+NFR&#8209;001: Non-breaking hyphen but not bold
+```
+
 ## Emphasis
 
 - Use `*` or `_` for emphasis (italic), `**` or `__` for strong emphasis (bold)

--- a/.github/prompts/specify.prompt.md
+++ b/.github/prompts/specify.prompt.md
@@ -118,6 +118,7 @@ Given that feature description, do this:
    - **If IS_EXISTING_BRANCH is true**:
      - Update the existing issue associated with this feature branch (if one exists) with the refined specification
      - **Evaluate if the title needs updating**: If the feature scope has changed significantly (e.g., from patch to feature, or major functionality changes), update the issue title. For minor refinements or clarifications, keep the existing title.
+     - **Ensure Specification label**: Verify the issue has the 'Specification' label (indicates current phase)
    - **If IS_EXISTING_BRANCH is false** (new branch): Create a new GitHub issue with:
      - Title: Use the generated title format above
      - Body: The complete content of the SPEC_FILE (spec.md). Remove the first H1 (#) header and the first H2 (##) header if they exist. We want the PR description to start with the "Primary user story" section.

--- a/.github/prompts/tasks.prompt.md
+++ b/.github/prompts/tasks.prompt.md
@@ -76,6 +76,10 @@ $ARGUMENTS
    - Clear file paths for each task
    - Dependency notes
    - Parallel execution guidance
+   - **IMPORTANT**: After each task in the task list, add a sub-step to update the PR description:
+     * Add: "After completing this task, update the PR description to mark this task as complete by changing `- [ ] T###:` to `- [X] T###:` in the Implementation Tasks section"
+     * This ensures that the PR description stays synchronized with actual progress
+     * Each task should have this update step included in its description or as a final action item
 
 8. Update the Pull Request description:
    - **Determine workflow mode and target repository**:


### PR DESCRIPTION
## Description

This pull request updates and clarifies the workflow instructions for planning and implementing features, with a strong focus on correct GitHub label management, improved documentation standards, and enhanced PR/release note formatting. The changes ensure that contributors follow standardized processes for labeling, documentation, and communication, making the workflow more consistent and user-friendly.

**Workflow and Label Management Improvements:**

* Both `.github/prompts/plan.prompt.md` and `.github/prompts/implement.prompt.md` now require setting and updating GitHub labels (like `Planning`, `Implementing`, `Specification`) at the start of each workflow, with clear instructions for both forked and local repositories. Fallback `gh` CLI commands are provided for manual updates. [[1]](diffhunk://#diff-68a2c56959d80cc612e224742a5036c1110c7d7242c7970cea384847a63d2f74L21-R53) [[2]](diffhunk://#diff-68a2c56959d80cc612e224742a5036c1110c7d7242c7970cea384847a63d2f74L117-R143) [[3]](diffhunk://#diff-c7d6853d6175b556ba7b64b7764e390cbbb6e49f9b76e9102e979225f4910d4dL19-R47) [[4]](diffhunk://#diff-c7d6853d6175b556ba7b64b7764e390cbbb6e49f9b76e9102e979225f4910d4dL98-R220)
* The implementation workflow now includes immediate label transitions (e.g., removing `Planning` and adding `Implementing`), and the planning workflow adds/removes `Planning` and `Specification` as appropriate. [[1]](diffhunk://#diff-c7d6853d6175b556ba7b64b7764e390cbbb6e49f9b76e9102e979225f4910d4dL19-R47) [[2]](diffhunk://#diff-68a2c56959d80cc612e224742a5036c1110c7d7242c7970cea384847a63d2f74L21-R53)

**Documentation and Formatting Standards:**

* Added a new section in `.github/instructions/md.instructions.md` specifying that all requirement numbers (e.g., NFR-001, FR-042) must be formatted in bold and use non-breaking hyphens to prevent line breaks and ensure consistency in all documentation.
* `.github/copilot-instructions.md` now mandates that all terminal commands in documentation be prefixed with `pwsh` (except for GitHub MCP calls), with examples provided for clarity.

**PR and Release Note Guidance:**

* The instructions for PR descriptions have been rewritten to require a user-focused, release-note style summary, with explicit sections for "What's Changed," "Usage," "Breaking Changes," and "Technical Notes." Example command-line instructions for updating PR descriptions are included.
* The planning workflow now requires PRs to include both a version/change-level label (e.g., Major, Minor, Patch) and a phase label (Planning), with fallback CLI commands for label management. [[1]](diffhunk://#diff-68a2c56959d80cc612e224742a5036c1110c7d7242c7970cea384847a63d2f74L100-R120) [[2]](diffhunk://#diff-68a2c56959d80cc612e224742a5036c1110c7d7242c7970cea384847a63d2f74L117-R143)

**Workflow Step Clarifications and Reordering:**

* Both planning and implementation prompts have been restructured and renumbered for clarity, with explicit instructions for each step, including constitution and changelog updates, commit message standards, and final PR/issue updates. [[1]](diffhunk://#diff-c7d6853d6175b556ba7b64b7764e390cbbb6e49f9b76e9102e979225f4910d4dL39-R57) [[2]](diffhunk://#diff-c7d6853d6175b556ba7b64b7764e390cbbb6e49f9b76e9102e979225f4910d4dL48-R127) [[3]](diffhunk://#diff-68a2c56959d80cc612e224742a5036c1110c7d7242c7970cea384847a63d2f74L55-R83)

**Changelog and Constitution Updates:**

* The implementation workflow now explicitly requires updating both the constitution and the changelog with each feature or change, following best practices for documentation and release management.

These changes collectively enforce best practices for workflow automation, documentation, and communication in the repository, improving clarity and consistency for all contributors.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
