### PR TITLE
🩹 [Docs]: Add suppressing output guidance to PowerShell style guidelines

### DIFF
--- a/.github/instructions/pwsh.instructions.md
+++ b/.github/instructions/pwsh.instructions.md
@@ -515,6 +515,36 @@ function Get-ProcessedData {
 }
 ```
 
+## Suppressing Output
+
+- Use `$null =` to suppress unwanted output from commands
+- Avoid using `| Out-Null` as it is significantly slower
+- Use `[void]` for method calls that return values you want to discard
+- This is especially important in loops or performance-critical code
+
+**Good:**
+
+```powershell
+# Suppress output from .NET method calls
+$null = $list.Add($item)
+$null = $collection.Remove($item)
+
+# Alternative for methods
+[void]$list.Add($item)
+
+# Suppress output from cmdlets
+$null = New-Item -Path $path -ItemType Directory
+```
+
+**Bad:**
+
+```powershell
+# Slower performance with Out-Null
+$list.Add($item) | Out-Null
+$collection.Remove($item) | Out-Null
+New-Item -Path $path -ItemType Directory | Out-Null
+```
+
 ## Pipeline
 
 - Design functions to accept pipeline input when appropriate


### PR DESCRIPTION
The PowerShell style guidelines now include comprehensive guidance on suppressing unwanted output from commands and methods. This addition helps developers choose the most performant approach when they need to discard function or method return values.

- Fixes #224

## Suppressing Output Section

A new section has been added to the PowerShell style guidelines (`pwsh.instructions.md`) that provides clear guidance on:

- **Using `$null =` for best performance** - The recommended approach for suppressing output from both cmdlets and .NET method calls
- **Using `[void]` as an alternative** - Another valid option specifically for method calls that return values
- **Avoiding `| Out-Null`** - Explicitly noting that this approach has significantly slower performance and should be avoided

The section includes practical examples showing both correct and incorrect usage patterns, making it easy for developers to follow the best practices.

## Performance Impact

This guidance is especially important in performance-critical code and loops, where the overhead of `| Out-Null` can accumulate and cause noticeable slowdowns. By using `$null =` or `[void]`, developers can ensure their scripts run efficiently.