### PR TITLE
🚀[Feature]: Use local PSScriptAnalyzer files

### DIFF
--- a/.github/workflows/Lint-SourceCode.yml
+++ b/.github/workflows/Lint-SourceCode.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint-SourceCode
-        uses: PSModule/Invoke-ScriptAnalyzer@v4
+        uses: PSModule/Invoke-ScriptAnalyzer@debugPath #v4
         with:
           Debug: ${{ inputs.Debug }}
           Prerelease: ${{ inputs.Prerelease }}

--- a/.github/workflows/Lint-SourceCode.yml
+++ b/.github/workflows/Lint-SourceCode.yml
@@ -56,14 +56,13 @@ jobs:
           fetch-depth: 0
 
       - name: Lint-SourceCode
-        uses: PSModule/Invoke-ScriptAnalyzer@v3
+        uses: PSModule/Invoke-ScriptAnalyzer@v4
         with:
           Debug: ${{ inputs.Debug }}
           Prerelease: ${{ inputs.Prerelease }}
           Verbose: ${{ inputs.Verbose }}
           Version: ${{ inputs.Version }}
           Path: src
-          Settings: SourceCode
           WorkingDirectory: ${{ inputs.WorkingDirectory }}
           TestResult_Enabled: true
           TestResult_TestSuiteName: PSModuleLint-SourceCode-${{ runner.os }}

--- a/.github/workflows/Lint-SourceCode.yml
+++ b/.github/workflows/Lint-SourceCode.yml
@@ -53,10 +53,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Lint-SourceCode
-        uses: PSModule/Invoke-ScriptAnalyzer@debugPath #v4
+        uses: PSModule/Invoke-ScriptAnalyzer@v4
         with:
           Debug: ${{ inputs.Debug }}
           Prerelease: ${{ inputs.Prerelease }}

--- a/.github/workflows/Test-Module.yml
+++ b/.github/workflows/Test-Module.yml
@@ -114,7 +114,7 @@ jobs:
           path: ${{ inputs.WorkingDirectory }}/outputs/module
 
       - name: Lint-Module
-        uses: PSModule/Invoke-ScriptAnalyzer@v3
+        uses: PSModule/Invoke-ScriptAnalyzer@v4
         with:
           Path: outputs/module
           Debug: ${{ inputs.Debug }}
@@ -122,6 +122,5 @@ jobs:
           Verbose: ${{ inputs.Verbose }}
           Version: ${{ inputs.Version }}
           WorkingDirectory: ${{ inputs.WorkingDirectory }}
-          Settings: Module
           TestResult_Enabled: true
           TestResult_TestSuiteName: PSModuleLint-Module-${{ runner.os }}

--- a/.github/workflows/Test-Module.yml
+++ b/.github/workflows/Test-Module.yml
@@ -84,7 +84,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Download module artifact
         uses: actions/download-artifact@v5
@@ -107,6 +106,11 @@ jobs:
     name: Lint-Module (${{ inputs.RunsOn }})
     runs-on: ${{ inputs.RunsOn }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
       - name: Download module artifact
         uses: actions/download-artifact@v5
         with:
@@ -114,7 +118,7 @@ jobs:
           path: ${{ inputs.WorkingDirectory }}/outputs/module
 
       - name: Lint-Module
-        uses: PSModule/Invoke-ScriptAnalyzer@debugPath #v4
+        uses: PSModule/Invoke-ScriptAnalyzer@v4
         with:
           Path: outputs/module
           Debug: ${{ inputs.Debug }}

--- a/.github/workflows/Test-Module.yml
+++ b/.github/workflows/Test-Module.yml
@@ -114,7 +114,7 @@ jobs:
           path: ${{ inputs.WorkingDirectory }}/outputs/module
 
       - name: Lint-Module
-        uses: PSModule/Invoke-ScriptAnalyzer@v4
+        uses: PSModule/Invoke-ScriptAnalyzer@debugPath #v4
         with:
           Path: outputs/module
           Debug: ${{ inputs.Debug }}

--- a/.github/workflows/Workflow-Test-WithManifest.yml
+++ b/.github/workflows/Workflow-Test-WithManifest.yml
@@ -25,5 +25,4 @@ jobs:
     secrets: inherit
     with:
       WorkingDirectory: tests/srcWithManifestTestRepo
-      Name: PSModuleTest2
       SettingsPath: .github/PSModule.yml

--- a/tests/srcWithManifestTestRepo/.github/linters/.powershell-psscriptanalyzer.psd1
+++ b/tests/srcWithManifestTestRepo/.github/linters/.powershell-psscriptanalyzer.psd1
@@ -1,0 +1,56 @@
+﻿@{
+    Rules        = @{
+        PSAlignAssignmentStatement         = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+        PSAvoidLongLines                   = @{
+            Enable            = $true
+            MaximumLineLength = 150
+        }
+        PSAvoidSemicolonsAsLineTerminators = @{
+            Enable = $true
+        }
+        PSPlaceCloseBrace                  = @{
+            Enable             = $true
+            NewLineAfter       = $false
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $false
+        }
+        PSPlaceOpenBrace                   = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+        PSProvideCommentHelp               = @{
+            Enable                  = $true
+            ExportedOnly            = $false
+            BlockComment            = $true
+            VSCodeSnippetCorrection = $false
+            Placement               = 'begin'
+        }
+        PSUseConsistentIndentation         = @{
+            Enable              = $true
+            IndentationSize     = 4
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+            Kind                = 'space'
+        }
+        PSUseConsistentWhitespace          = @{
+            Enable                                  = $true
+            CheckInnerBrace                         = $true
+            CheckOpenBrace                          = $true
+            CheckOpenParen                          = $true
+            CheckOperator                           = $true
+            CheckPipe                               = $true
+            CheckPipeForRedundantWhitespace         = $true
+            CheckSeparator                          = $true
+            CheckParameter                          = $true
+            IgnoreAssignmentOperatorInsideHashTable = $true
+        }
+    }
+    ExcludeRules = @(
+        'PSMissingModuleManifestField', # This rule is not applicable until the module is built.
+        'PSUseToExportFieldsInManifest'
+    )
+}


### PR DESCRIPTION
The workflow now uses [Invoke-ScriptAnalyzer@v4](https://github.com/PSModule/Invoke-ScriptAnalyzer), enabling automatic discovery of local PSScriptAnalyzer configuration files. This allows projects to maintain custom linting rules in their repository without requiring centralized settings management. The upgrade also streamlines workflow configuration by removing deprecated parameters and improving checkout efficiency.

## Updated to PSScriptAnalyzer v4

Upgraded the `PSModule/Invoke-ScriptAnalyzer` action from v3 to v4 in linting workflows (`Lint-SourceCode.yml` and `Test-Module.yml`). This version automatically discovers and uses local `.powershell-psscriptanalyzer.psd1` configuration files from the `.github/linters/` directory, providing better support for repository-specific linting rules.

## Removed Deprecated Settings Parameter

The `Settings` parameter has been removed from both `Lint-SourceCode` and `Lint-Module` workflow steps. PSScriptAnalyzer now automatically discovers local configuration files, eliminating the need to explicitly specify settings profiles.

## Workflow Configuration Improvements

- Added a `Checkout repository` step to the `Lint-Module` job to ensure the codebase (including local configuration files) is available before linting
- Removed `fetch-depth: 0` from checkout steps to use shallow clones, reducing workflow execution time
- Removed unused `Name` parameter from test workflow

## Custom Linting Configuration Support

Added a `.powershell-psscriptanalyzer.psd1` configuration file in the test repository (`tests/srcWithManifestTestRepo/.github/linters/`) demonstrating how projects can define custom code style rules, including formatting preferences, line length limits, and rule exclusions.