### PR TITLE
🩹 [Patch]: Make secrets available in `BeforeAll` and `AfterAll` jobs

### DIFF
--- a/.github/workflows/AfterAll-ModuleLocal.yml
+++ b/.github/workflows/AfterAll-ModuleLocal.yml
@@ -2,11 +2,42 @@ name: AfterAll-ModuleLocal
 
 on:
   workflow_call:
+    secrets:
+      TEST_APP_ENT_CLIENT_ID:
+        description: The client ID of an Enterprise GitHub App for running tests.
+        required: false
+      TEST_APP_ENT_PRIVATE_KEY:
+        description: The private key of an Enterprise GitHub App for running tests.
+        required: false
+      TEST_APP_ORG_CLIENT_ID:
+        description: The client ID of an Organization GitHub App for running tests.
+        required: false
+      TEST_APP_ORG_PRIVATE_KEY:
+        description: The private key of an Organization GitHub App for running tests.
+        required: false
+      TEST_USER_ORG_FG_PAT:
+        description: The fine-grained personal access token with org access for running tests.
+        required: false
+      TEST_USER_USER_FG_PAT:
+        description: The fine-grained personal access token with user account access for running tests.
+        required: false
+      TEST_USER_PAT:
+        description: The classic personal access token for running tests.
+        required: false
     inputs:
       Settings:
         type: string
         description: The complete settings object including test suites.
         required: true
+
+env:
+  TEST_APP_ENT_CLIENT_ID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
+  TEST_APP_ENT_PRIVATE_KEY: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
+  TEST_APP_ORG_CLIENT_ID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
+  TEST_APP_ORG_PRIVATE_KEY: ${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}
+  TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
+  TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
+  TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
 
 permissions:
   contents: read # to checkout the repo

--- a/.github/workflows/BeforeAll-ModuleLocal.yml
+++ b/.github/workflows/BeforeAll-ModuleLocal.yml
@@ -2,11 +2,42 @@ name: BeforeAll-ModuleLocal
 
 on:
   workflow_call:
+    secrets:
+      TEST_APP_ENT_CLIENT_ID:
+        description: The client ID of an Enterprise GitHub App for running tests.
+        required: false
+      TEST_APP_ENT_PRIVATE_KEY:
+        description: The private key of an Enterprise GitHub App for running tests.
+        required: false
+      TEST_APP_ORG_CLIENT_ID:
+        description: The client ID of an Organization GitHub App for running tests.
+        required: false
+      TEST_APP_ORG_PRIVATE_KEY:
+        description: The private key of an Organization GitHub App for running tests.
+        required: false
+      TEST_USER_ORG_FG_PAT:
+        description: The fine-grained personal access token with org access for running tests.
+        required: false
+      TEST_USER_USER_FG_PAT:
+        description: The fine-grained personal access token with user account access for running tests.
+        required: false
+      TEST_USER_PAT:
+        description: The classic personal access token for running tests.
+        required: false
     inputs:
       Settings:
         type: string
         description: The complete settings object including test suites.
         required: true
+
+env:
+  TEST_APP_ENT_CLIENT_ID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
+  TEST_APP_ENT_PRIVATE_KEY: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
+  TEST_APP_ORG_CLIENT_ID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
+  TEST_APP_ORG_PRIVATE_KEY: ${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}
+  TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
+  TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
+  TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
 
 permissions:
   contents: read # to checkout the repo

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -157,6 +157,14 @@ jobs:
   BeforeAll-ModuleLocal:
     if: fromJson(needs.Get-Settings.outputs.Settings).Run.BeforeAllModuleLocal && needs.Build-Module.result == 'success' && !cancelled()
     uses: ./.github/workflows/BeforeAll-ModuleLocal.yml
+    secrets:
+      TEST_APP_ENT_CLIENT_ID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
+      TEST_APP_ENT_PRIVATE_KEY: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
+      TEST_APP_ORG_CLIENT_ID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
+      TEST_APP_ORG_PRIVATE_KEY: ${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}
+      TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
+      TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
+      TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
     needs:
       - Build-Module
       - Get-Settings
@@ -187,6 +195,14 @@ jobs:
   AfterAll-ModuleLocal:
     if: fromJson(needs.Get-Settings.outputs.Settings).Run.AfterAllModuleLocal && needs.Test-ModuleLocal.result != 'skipped' && always()
     uses: ./.github/workflows/AfterAll-ModuleLocal.yml
+    secrets:
+      TEST_APP_ENT_CLIENT_ID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
+      TEST_APP_ENT_PRIVATE_KEY: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
+      TEST_APP_ORG_CLIENT_ID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
+      TEST_APP_ORG_PRIVATE_KEY: ${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}
+      TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
+      TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
+      TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
     needs:
       - Get-Settings
       - Test-ModuleLocal

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -145,7 +145,6 @@ jobs:
       - Build-Module
       - Get-Settings
     uses: ./.github/workflows/Test-Module.yml
-    secrets: inherit
     with:
       Settings: ${{ needs.Get-Settings.outputs.Settings }}
 
@@ -183,7 +182,14 @@ jobs:
       - Get-Settings
       - BeforeAll-ModuleLocal
     uses: ./.github/workflows/Test-ModuleLocal.yml
-    secrets: inherit
+    secrets:
+      TEST_APP_ENT_CLIENT_ID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
+      TEST_APP_ENT_PRIVATE_KEY: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
+      TEST_APP_ORG_CLIENT_ID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
+      TEST_APP_ORG_PRIVATE_KEY: ${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}
+      TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
+      TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
+      TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
     with:
       Settings: ${{ needs.Get-Settings.outputs.Settings }}
 
@@ -223,7 +229,6 @@ jobs:
       - Test-Module
       - Test-ModuleLocal
     uses: ./.github/workflows/Get-TestResults.yml
-    secrets: inherit
     with:
       Settings: ${{ needs.Get-Settings.outputs.Settings }}
 
@@ -239,7 +244,6 @@ jobs:
       - Test-Module
       - Test-ModuleLocal
     uses: ./.github/workflows/Get-CodeCoverage.yml
-    secrets: inherit
     with:
       Settings: ${{ needs.Get-Settings.outputs.Settings }}
 
@@ -251,7 +255,8 @@ jobs:
   Publish-Module:
     if: fromJson(needs.Get-Settings.outputs.Settings).Run.PublishModule && needs.Get-Settings.result == 'success' && !cancelled() && (needs.Get-TestResults.result == 'success' || needs.Get-TestResults.result == 'skipped') && (needs.Get-CodeCoverage.result == 'success' || needs.Get-CodeCoverage.result == 'skipped') && (needs.Build-Site.result == 'success' || needs.Build-Site.result == 'skipped')
     uses: ./.github/workflows/Publish-Module.yml
-    secrets: inherit
+    secrets:
+      APIKey: ${{ secrets.APIKey }}
     needs:
       - Get-Settings
       - Get-TestResults


### PR DESCRIPTION
This patch release makes test secrets available in the `BeforeAll-ModuleLocal` and `AfterAll-ModuleLocal` workflow jobs, enabling proper test setup and teardown operations that require authentication credentials.

### Changes

- **Updated workflow files** to pass test secrets through reusable workflow calls:
  - [.github/workflows/BeforeAll-ModuleLocal.yml](.github/workflows/BeforeAll-ModuleLocal.yml) - Added secrets input and environment variable mapping
  - [.github/workflows/AfterAll-ModuleLocal.yml](.github/workflows/AfterAll-ModuleLocal.yml) - Added secrets input and environment variable mapping
  - [.github/workflows/workflow.yml](.github/workflows/workflow.yml) - Configured secret passing to BeforeAll and AfterAll jobs
