### PR TITLE
🩹 [Patch]: Bump Get-PSModuleSettings action to version 1.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,6 @@ updates:
       - dependencies
       - github-actions
     schedule:
-      interval: weekly
+      interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/workflows/Auto-Release.yml
+++ b/.github/workflows/Auto-Release.yml
@@ -3,7 +3,7 @@ name: Auto-Release
 run-name: "Auto-Release - [${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}] by @${{ github.actor }}"
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types:
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Auto-Release
         uses: PSModule/Auto-Release@eabd533035e2cb9822160f26f2eda584bd012356 # v1.9.5

--- a/.github/workflows/Build-Docs.yml
+++ b/.github/workflows/Build-Docs.yml
@@ -95,11 +95,13 @@ jobs:
       - name: Post super-linter summary
         if: failure() || fromJson(inputs.Settings).Build.Docs.ShowSummaryOnSuccess == true
         shell: pwsh
+        env:
+          SUPER_LINTER_OUTCOME: ${{ steps.super-linter.outcome }}
         run: |
           $summaryPath = Join-Path $env:GITHUB_WORKSPACE 'super-linter-output' 'super-linter-summary.md'
           Get-Content $summaryPath | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
 
-          $failed = '${{ steps.super-linter.outcome }}' -eq 'failure'
+          $failed = $env:SUPER_LINTER_OUTCOME -eq 'failure'
           if ($failed) {
               Write-Host "::error::Super-linter found issues. Please review the summary above."
               exit 1

--- a/.github/workflows/Get-Settings.yml
+++ b/.github/workflows/Get-Settings.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Get-Settings
-        uses: PSModule/Get-PSModuleSettings@77c3c599734effaecc3a868a34bf39ab0ca7f0a0 # v1.0.0
+        uses: PSModule/Get-PSModuleSettings@9c811d04acb8aa8f7a224f0662d6b85aa1323b3d # v1.0.1
         id: Get-Settings
         with:
           SettingsPath: ${{ inputs.SettingsPath }}

--- a/.github/workflows/Lint-Repository.yml
+++ b/.github/workflows/Lint-Repository.yml
@@ -59,11 +59,13 @@ jobs:
       - name: Post super-linter summary
         if: failure() || fromJson(env.Settings).Linter.ShowSummaryOnSuccess == true
         shell: pwsh
+        env:
+          SUPER_LINTER_OUTCOME: ${{ steps.super-linter.outcome }}
         run: |
           $summaryPath = Join-Path $env:GITHUB_WORKSPACE 'super-linter-output' 'super-linter-summary.md'
           Get-Content $summaryPath | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
 
-          $failed = '${{ steps.super-linter.outcome }}' -eq 'failure'
+          $failed = $env:SUPER_LINTER_OUTCOME -eq 'failure'
           if ($failed) {
               Write-Host "::error::Super-linter found issues. Please review the summary above."
               exit 1

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -28,11 +28,8 @@ jobs:
         uses: super-linter/super-linter@47984f49b4e87383eed97890fe2dca6063bbd9c3 # v8.3.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          # VALIDATE_BIOME_FORMAT: false
-          # VALIDATE_BIOME_LINT: false
-          # VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
-          # VALIDATE_JSCPD: false
-          # VALIDATE_JSON_PRETTIER: false
-          # VALIDATE_MARKDOWN_PRETTIER: false
-          # VALIDATE_YAML_PRETTIER: false
-
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_JSCPD: false
+          VALIDATE_JSON_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -28,11 +28,11 @@ jobs:
         uses: super-linter/super-linter@47984f49b4e87383eed97890fe2dca6063bbd9c3 # v8.3.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          VALIDATE_BIOME_FORMAT: false
-          VALIDATE_BIOME_LINT: false
-          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
-          VALIDATE_JSCPD: false
-          VALIDATE_JSON_PRETTIER: false
-          VALIDATE_MARKDOWN_PRETTIER: false
-          VALIDATE_YAML_PRETTIER: false
+          # VALIDATE_BIOME_FORMAT: false
+          # VALIDATE_BIOME_LINT: false
+          # VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          # VALIDATE_JSCPD: false
+          # VALIDATE_JSON_PRETTIER: false
+          # VALIDATE_MARKDOWN_PRETTIER: false
+          # VALIDATE_YAML_PRETTIER: false
 

--- a/.github/workflows/Workflow-Test-Default.yml
+++ b/.github/workflows/Workflow-Test-Default.yml
@@ -22,6 +22,14 @@ permissions:
 jobs:
   WorkflowTestDefault:
     uses: ./.github/workflows/workflow.yml
-    secrets: inherit
+    secrets:
+      APIKey: ${{ secrets.APIKey }}
+      TEST_APP_ENT_CLIENT_ID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
+      TEST_APP_ENT_PRIVATE_KEY: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
+      TEST_APP_ORG_CLIENT_ID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
+      TEST_APP_ORG_PRIVATE_KEY: ${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}
+      TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
+      TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
+      TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
     with:
       WorkingDirectory: tests/srcTestRepo

--- a/.github/workflows/Workflow-Test-WithManifest.yml
+++ b/.github/workflows/Workflow-Test-WithManifest.yml
@@ -22,6 +22,14 @@ permissions:
 jobs:
   WorkflowTestWithManifest:
     uses: ./.github/workflows/workflow.yml
-    secrets: inherit
+    secrets:
+      APIKey: ${{ secrets.APIKey }}
+      TEST_APP_ENT_CLIENT_ID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
+      TEST_APP_ENT_PRIVATE_KEY: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
+      TEST_APP_ORG_CLIENT_ID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
+      TEST_APP_ORG_PRIVATE_KEY: ${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}
+      TEST_USER_ORG_FG_PAT: ${{ secrets.TEST_USER_ORG_FG_PAT }}
+      TEST_USER_USER_FG_PAT: ${{ secrets.TEST_USER_USER_FG_PAT }}
+      TEST_USER_PAT: ${{ secrets.TEST_USER_PAT }}
     with:
       WorkingDirectory: tests/srcWithManifestTestRepo


### PR DESCRIPTION
### Fixed
- Bumped `PSModule/Get-PSModuleSettings` to v1.0.1.
- Super-linter summary now reads `super-linter` outcome via an environment variable to avoid expression parsing quirks.
- Workflow tests now pass explicit secrets instead of using `secrets: inherit`.

### Changed
- Dependabot update cadence is now daily with a 7-day cooldown.
- Auto-Release now runs on `pull_request` and checks out with `persist-credentials: false`.
- Removed unused linter env toggles for Biome lint and enabled Zizmor for GitHub Actions.