### PR TITLE
🩹 [Patch]: Update Get-PSModuleSettings action to version 1.0.3

### DIFF
--- a/.github/workflows/Get-Settings.yml
+++ b/.github/workflows/Get-Settings.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Get-Settings
-        uses: PSModule/Get-PSModuleSettings@58d80d7c7a62d8a9be0240cd86d31af5a95ab8f6 # v1.0.2
+        uses: PSModule/Get-PSModuleSettings@5be814463ddf37293196c5bd07c861f6fb617a59 # v1.0.3
         id: Get-Settings
         with:
           SettingsPath: ${{ inputs.SettingsPath }}


### PR DESCRIPTION
This pull request updates the `Get-PSModuleSettings` GitHub Action to a newer version in the workflow configuration file. This ensures the workflow uses the latest improvements and bug fixes from the action's upstream repository.

- Fixes #260

Workflow update:
* Updated the `Get-PSModuleSettings` action in `.github/workflows/Get-Settings.yml` from version `v1.0.2` to `v1.0.3` to incorporate the latest changes and fixes.