### PR TITLE
🪲[Fix]: Fix permissions to allow commenting on pull requests and make releases

### DIFF
--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read # to checkout the repo
+  pull-requests: write # to comment on PRs
 
 jobs:
   Publish-Module:

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -13,7 +13,7 @@ on:
         required: true
 
 permissions:
-  contents: read # to checkout the repo
+  contents: write # to checkout the repo and create releases
   pull-requests: write # to comment on PRs
 
 jobs:


### PR DESCRIPTION
This release fixes a bug to the GitHub Actions workflow permissions. The change grants write access to pull requests, which will allow the workflow to:
- comment on PRs
- manage releases