### PR TITLE
⚙️ [Maintenance]: Dependency versions updated including setup/teardown job optimization

### DIFF
--- a/.github/workflows/Build-Docs.yml
+++ b/.github/workflows/Build-Docs.yml
@@ -36,7 +36,7 @@ jobs:
           WorkingDirectory: ${{ fromJson(inputs.Settings).WorkingDirectory }}
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: docs
           path: ${{ fromJson(inputs.Settings).WorkingDirectory }}/outputs/docs

--- a/.github/workflows/Build-Docs.yml
+++ b/.github/workflows/Build-Docs.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download module artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: module
           path: ${{ fromJson(inputs.Settings).WorkingDirectory }}/outputs/module

--- a/.github/workflows/Build-Module.yml
+++ b/.github/workflows/Build-Module.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build module
-        uses: PSModule/Build-PSModule@869da3f28cbb5c04c6868dded0d511a40f191a59 # v4.0.12
+        uses: PSModule/Build-PSModule@7a3ae1be38587e8051833d85ffa53c348de3cd0d # v4.0.13
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           ArtifactName: ${{ inputs.ArtifactName }}

--- a/.github/workflows/Build-Site.yml
+++ b/.github/workflows/Build-Site.yml
@@ -26,7 +26,7 @@ jobs:
         uses: PSModule/Install-PSModuleHelpers@ed79b6e3aa8c9cd3d30ab2bf02ea6bd4687b9c74 # v1.0.7
 
       - name: Download docs artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: docs
           path: ${{ fromJson(inputs.Settings).WorkingDirectory }}/outputs/docs

--- a/.github/workflows/Get-Settings.yml
+++ b/.github/workflows/Get-Settings.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: Get-Settings
-        uses: PSModule/Get-PSModuleSettings@3d53e12a48fb35bc68f55ec438f8a14805758009 # v1.4.3
+        uses: PSModule/Get-PSModuleSettings@21c88f499579f56a60cced37872089d866b94a66 # v1.4.4
         id: Get-Settings
         with:
           SettingsPath: ${{ inputs.SettingsPath }}

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish module
-        uses: PSModule/Publish-PSModule@2e548cfd1c68b76129fdeabc7f7caebd47e3b1c3 # v2.2.2
+        uses: PSModule/Publish-PSModule@207c39b9eff2118d0e4eabff78e90f7015bc36da # v2.2.3
         env:
           GH_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Test-Module.yml
+++ b/.github/workflows/Test-Module.yml
@@ -57,7 +57,7 @@ jobs:
           persist-credentials: false
 
       - name: Download module artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: module
           path: ${{ fromJson(inputs.Settings).WorkingDirectory }}/outputs/module
@@ -87,7 +87,7 @@ jobs:
           persist-credentials: false
 
       - name: Download module artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: module
           path: ${{ fromJson(inputs.Settings).WorkingDirectory }}/outputs/module

--- a/.github/workflows/Test-ModuleLocal.yml
+++ b/.github/workflows/Test-ModuleLocal.yml
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download module artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: module
           path: ${{ fromJson(inputs.Settings).WorkingDirectory }}/outputs/module

--- a/.github/workflows/Test-ModuleLocal.yml
+++ b/.github/workflows/Test-ModuleLocal.yml
@@ -79,7 +79,7 @@ jobs:
           "path=$path" >> $env:GITHUB_OUTPUT
 
       - name: Test-ModuleLocal
-        uses: PSModule/Invoke-Pester@1fcb663c0efe914e8374d78e16aa7bb907ea2434 # v4.2.3
+        uses: PSModule/Invoke-Pester@abddf7bef0d0614d7ca322036af6a06ee0fb4d44 # v4.2.4
         with:
           Debug: ${{ fromJson(inputs.Settings).Debug }}
           Prerelease: ${{ fromJson(inputs.Settings).Prerelease }}


### PR DESCRIPTION
All action and workflow dependencies are updated to their latest versions. This includes the fix from PSModule/Get-PSModuleSettings v1.4.4 that skips `BeforeAll-ModuleLocal` and `AfterAll-ModuleLocal` jobs when the corresponding setup/teardown scripts do not exist, saving runner time for the majority of repositories.

- Fixes #288

## Changed: Dependency versions

| Action | From | To |
| :--- | :--- | :--- |
| `actions/download-artifact` | v7.0.0 | v8.0.0 |
| `actions/upload-artifact` | v6.0.0 | v7.0.0 |
| `PSModule/Build-PSModule` | v4.0.12 | v4.0.13 |
| `PSModule/Publish-PSModule` | v2.2.2 | v2.2.3 |
| `PSModule/Invoke-Pester` | v4.2.3 | v4.2.4 |
| `PSModule/Get-PSModuleSettings` | v1.4.3 | v1.4.4 |

## Changed: Runner allocation for setup/teardown jobs

With the `Get-PSModuleSettings` v1.4.4 update, repositories without `tests/BeforeAll.ps1` or `tests/AfterAll.ps1` no longer allocate runners for the `BeforeAll-ModuleLocal` and `AfterAll-ModuleLocal` jobs. These jobs are now skipped entirely at the settings evaluation stage, before any runner is provisioned.

## Technical Details

- All changes are SHA pin updates in `.github/workflows/*.yml` files — no logic or structural changes to the reusable workflows themselves.
- The `Get-PSModuleSettings` bump (`v1.4.3` → `v1.4.4`) is the key change that implements #288. The action now runs `Test-Path` checks for the setup/teardown scripts and sets the `Run.BeforeAllModuleLocal` / `Run.AfterAllModuleLocal` flags accordingly, which the existing workflow `if:` conditions already respect.