### PR TITLE
🩹 [Patch]: Setup/teardown jobs no longer waste runner time when scripts are absent

### DIFF
--- a/.github/workflows/Get-Settings.yml
+++ b/.github/workflows/Get-Settings.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: Get-Settings
-        uses: PSModule/Get-PSModuleSettings@3d53e12a48fb35bc68f55ec438f8a14805758009 # v1.4.3
+        uses: PSModule/Get-PSModuleSettings@21c88f499579f56a60cced37872089d866b94a66 # v1.4.4
         id: Get-Settings
         with:
           SettingsPath: ${{ inputs.SettingsPath }}


### PR DESCRIPTION
The `BeforeAll-ModuleLocal` and `AfterAll-ModuleLocal` workflow jobs no longer allocate runners when the corresponding `tests/BeforeAll.ps1` or `tests/AfterAll.ps1` scripts do not exist in the repository. Repositories without setup/teardown scripts now skip these jobs entirely, saving runner time on every workflow run.

- Fixes #288

## Changed: Runner allocation for setup/teardown jobs

With the `Get-PSModuleSettings` v1.4.4 update, repositories without `tests/BeforeAll.ps1` or `tests/AfterAll.ps1` no longer allocate runners for the `BeforeAll-ModuleLocal` and `AfterAll-ModuleLocal` jobs. These jobs are now skipped entirely at the settings evaluation stage, before any runner is provisioned.

Previously, both jobs always spun up a runner — even when there was nothing to execute. The runner would check out the repo, invoke the GitHub-Script action, find no script, and exit gracefully. This wasted runner time on every workflow run for the majority of repositories.

Additionally, `AfterAllModuleLocal` was previously set to `$true` unconditionally. It now uses the same base conditions as `BeforeAllModuleLocal` combined with the script existence check. The workflow-level `always()` condition remains as an additional safeguard for cleanup-after-failure scenarios.

## Technical Details

- Bumps `PSModule/Get-PSModuleSettings` from `v1.4.3` (`3d53e12`) to `v1.4.4` (`21c88f4`) in `Get-Settings.yml`.
- The action change ([PSModule/Get-PSModuleSettings#18](https://github.com/PSModule/Get-PSModuleSettings/pull/18)) adds `Test-Path` checks for the setup/teardown scripts and sets the `Run.BeforeAllModuleLocal` / `Run.AfterAllModuleLocal` flags accordingly, which the existing workflow `if:` conditions already respect.
- No structural changes to any reusable workflow files — only a SHA pin update.