### PR TITLE
🚀 [Feature]: Release-triggering file patterns now configurable via workflow input

### DIFF
--- a/.github/workflows/Get-Settings.yml
+++ b/.github/workflows/Get-Settings.yml
@@ -32,6 +32,13 @@ on:
         description: The path to the root of the repo.
         required: false
         default: '.'
+      ImportantFilePatterns:
+        type: string
+        description: |
+          Newline-separated list of regex patterns that identify important files.
+          Changes matching these patterns trigger build, test, and publish stages.
+          When set, fully replaces the defaults (^src/ and ^README\.md$).
+        required: false
 
     outputs:
       Settings:
@@ -65,3 +72,4 @@ jobs:
           Verbose: ${{ inputs.Verbose }}
           Version: ${{ inputs.Version }}
           WorkingDirectory: ${{ inputs.WorkingDirectory }}
+          ImportantFilePatterns: ${{ inputs.ImportantFilePatterns }}

--- a/.github/workflows/Get-Settings.yml
+++ b/.github/workflows/Get-Settings.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
 
       - name: Get-Settings
-        uses: PSModule/Get-PSModuleSettings@21c88f499579f56a60cced37872089d866b94a66 # v1.4.4
+        uses: PSModule/Get-PSModuleSettings@1e3d156786c56e6fbd839a1ba5ab21ff8858090e # v1.5.0
         id: Get-Settings
         with:
           SettingsPath: ${{ inputs.SettingsPath }}

--- a/.github/workflows/Get-Settings.yml
+++ b/.github/workflows/Get-Settings.yml
@@ -39,6 +39,9 @@ on:
           Changes matching these patterns trigger build, test, and publish stages.
           When set, fully replaces the defaults (^src/ and ^README\.md$).
         required: false
+        default: |
+          ^src/
+          ^README\.md$
 
     outputs:
       Settings:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,9 +68,6 @@ on:
         default: |
           ^src/
           ^README\.md$
-        default: |
-          ^src/
-          ^README\.md$
 
 permissions:
   contents: write      # to checkout the repo and create releases on the repo

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -65,6 +65,9 @@ on:
           Changes matching these patterns trigger build, test, and publish stages.
           When set, fully replaces the defaults (^src/ and ^README\.md$).
         required: false
+        default: |
+          ^src/
+          ^README\.md$
 
 permissions:
   contents: write      # to checkout the repo and create releases on the repo

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -58,6 +58,13 @@ on:
         description: The path to the root of the repo.
         required: false
         default: '.'
+      ImportantFilePatterns:
+        type: string
+        description: |
+          Newline-separated list of regex patterns that identify important files.
+          Changes matching these patterns trigger build, test, and publish stages.
+          When set, fully replaces the defaults (^src/ and ^README\.md$).
+        required: false
 
 permissions:
   contents: write      # to checkout the repo and create releases on the repo
@@ -81,6 +88,7 @@ jobs:
       Verbose: ${{ inputs.Verbose }}
       Version: ${{ inputs.Version }}
       WorkingDirectory: ${{ inputs.WorkingDirectory }}
+      ImportantFilePatterns: ${{ inputs.ImportantFilePatterns }}
 
   # Runs on:
   # - ✅ Open/Updated PR - Lints code changes in active PRs

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,6 +68,9 @@ on:
         default: |
           ^src/
           ^README\.md$
+        default: |
+          ^src/
+          ^README\.md$
 
 permissions:
   contents: write      # to checkout the repo and create releases on the repo

--- a/README.md
+++ b/README.md
@@ -500,8 +500,10 @@ jobs:
         ^examples/
 ```
 
-To disable triggering via workflow input, pass an empty string or omit the `with:` block entirely and rely on the
-settings file instead.
+To disable triggering via workflow input, pass an explicit empty string. Note that omitting the input entirely causes
+the workflow's default patterns (`^src/` and `^README\.md$`) to be used — the settings file takes priority over the
+workflow input, so set `ImportantFilePatterns: []` in `.github/PSModule.yml` to disable triggering regardless of the
+workflow input.
 
 Resolution order: settings file → workflow input → hardcoded defaults.
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ jobs:
 | `Version` | `string` | Specifies the version of the GitHub module to be installed. The value must be an exact version. | `false` | `''` |
 | `Prerelease` | `boolean` | Whether to use a prerelease version of the 'GitHub' module. | `false` | `false` |
 | `WorkingDirectory` | `string` | The path to the root of the repo. | `false` | `'.'` |
+| `ImportantFilePatterns` | `string` | Newline-separated list of regular expression patterns that identify important files. Changes matching these patterns trigger build, test, and publish stages. When set, fully replaces the defaults. | `false` | `^src/` and `^README\.md$` |
 
 ### Secrets
 
@@ -445,12 +446,43 @@ The workflow automatically detects whether a pull request contains changes to "i
 release. This prevents unnecessary releases when only non-functional files (such as workflow configurations, linter
 settings, or test files) are modified.
 
-#### Files that trigger releases
+#### Default patterns
 
-| Path | Description |
+By default, the following regular expression patterns identify important files:
+
+| Pattern | Description |
 | :--- | :---------- |
-| `src/**` | Module source code |
-| `README.md` | Module documentation |
+| `^src/` | Module source code |
+| `^README\.md$` | Module documentation |
+
+#### Customizing important file patterns
+
+To override the default patterns, set `ImportantFilePatterns` in your settings file (`.github/PSModule.yml`):
+
+```yaml
+ImportantFilePatterns:
+  - '^src/'
+  - '^README\.md$'
+  - '^examples/'
+```
+
+When configured, the provided list fully replaces the defaults. Include the default patterns in your list if you still
+want them to trigger releases.
+
+You can also pass patterns via the workflow input:
+
+```yaml
+jobs:
+  Process:
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v1
+    with:
+      ImportantFilePatterns: |
+        ^src/
+        ^README\.md$
+        ^examples/
+```
+
+Resolution order: settings file → workflow input → hardcoded defaults.
 
 #### Files that do NOT trigger releases
 
@@ -459,14 +491,14 @@ Changes to the following files will not trigger a release:
 - `.github/workflows/*` - Workflow configurations
 - `.github/linters/*` - Linter configuration files
 - `tests/**` - Test files
-- `examples/**` - Example scripts
 - `.gitignore`, `.editorconfig`, etc. - Repository configuration files
 
 #### Behavior when no important files are changed
 
 When a pull request does not contain changes to important files:
 
-1. A comment is automatically added to the PR explaining why build/test stages are skipped
+1. A comment is automatically added to the PR listing the configured patterns and explaining why build/test stages are
+   skipped
 2. The `ReleaseType` output is set to `None`
 3. Build, test, and publish stages are skipped
 4. The PR can still be merged for non-release changes (documentation updates, CI improvements, etc.)
@@ -484,6 +516,7 @@ The following settings are available in the settings file:
 | Name                                      | Type      | Description                                                                                                                                                          | Default             |
 | ----------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
 | `Name`                                    | `String`  | Name of the module to publish. Defaults to the repository name.                                                                                                      | `null`              |
+| `ImportantFilePatterns`                    | `Array`   | Regular expression patterns that identify important files. Changes matching these patterns trigger build, test, and publish stages. When set, fully replaces the defaults. | `['^src/', '^README\.md$']` |
 | `Test.Skip`                               | `Boolean` | Skip all tests                                                                                                                                                       | `false`             |
 | `Test.Linux.Skip`                         | `Boolean` | Skip tests on Linux                                                                                                                                                  | `false`             |
 | `Test.MacOS.Skip`                         | `Boolean` | Skip tests on macOS                                                                                                                                                  | `false`             |
@@ -531,6 +564,10 @@ The following settings are available in the settings file:
 
 ```yaml
 Name: null
+
+ImportantFilePatterns:
+  - '^src/'
+  - '^README\.md$'
 
 Build:
   Skip: false

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ jobs:
 | `Version` | `string` | Specifies the version of the GitHub module to be installed. The value must be an exact version. | `false` | `''` |
 | `Prerelease` | `boolean` | Whether to use a prerelease version of the 'GitHub' module. | `false` | `false` |
 | `WorkingDirectory` | `string` | The path to the root of the repo. | `false` | `'.'` |
-| `ImportantFilePatterns` | `string` | Newline-separated list of regular expression patterns that identify important files. Changes matching these patterns trigger build, test, and publish stages. When set, fully replaces the defaults. | `false` | `^src/` and `^README\.md$` |
+| `ImportantFilePatterns` | `string` | Newline-separated list of regular expression patterns that identify important files. Changes matching these patterns trigger build, test, and publish stages. When set, fully replaces the defaults. | `false` | `^src/\n^README\.md$` |
 
 ### Secrets
 

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ The workflow automatically detects whether a pull request contains changes to "i
 release. This prevents unnecessary releases when only non-functional files (such as workflow configurations, linter
 settings, or test files) are modified.
 
-#### Default patterns
+#### Files that trigger releases
 
 By default, the following regular expression patterns identify important files:
 

--- a/README.md
+++ b/README.md
@@ -507,15 +507,6 @@ workflow input.
 
 Resolution order: settings file → workflow input → hardcoded defaults.
 
-#### Files that do NOT trigger releases
-
-Changes to the following files will not trigger a release:
-
-- `.github/workflows/*` - Workflow configurations
-- `.github/linters/*` - Linter configuration files
-- `tests/**` - Test files
-- `.gitignore`, `.editorconfig`, etc. - Repository configuration files
-
 #### Behavior when no important files are changed
 
 When a pull request does not contain changes to important files:

--- a/README.md
+++ b/README.md
@@ -480,6 +480,13 @@ ImportantFilePatterns:
 When configured, the provided list fully replaces the defaults. Include the default patterns in your list if you still
 want them to trigger releases.
 
+To disable file-change triggering entirely (so that no file changes ever trigger a release), set an empty list in the
+settings file:
+
+```yaml
+ImportantFilePatterns: []
+```
+
 You can also pass patterns via the workflow input:
 
 ```yaml
@@ -492,6 +499,9 @@ jobs:
         ^README\.md$
         ^examples/
 ```
+
+To disable triggering via workflow input, pass an empty string or omit the `with:` block entirely and rely on the
+settings file instead.
 
 Resolution order: settings file → workflow input → hardcoded defaults.
 

--- a/README.md
+++ b/README.md
@@ -500,10 +500,19 @@ jobs:
         ^examples/
 ```
 
-To disable triggering via workflow input, pass an explicit empty string. Note that omitting the input entirely causes
-the workflow's default patterns (`^src/` and `^README\.md$`) to be used — the settings file takes priority over the
-workflow input, so set `ImportantFilePatterns: []` in `.github/PSModule.yml` to disable triggering regardless of the
-workflow input.
+To disable triggering via the workflow input, pass an explicit empty string:
+
+```yaml
+jobs:
+  process:
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    with:
+      ImportantFilePatterns: ''
+```
+
+Note that omitting the `ImportantFilePatterns` key entirely causes the workflow's default patterns (`^src/` and
+`^README\.md$`) to be used. The settings file takes priority over the workflow input, so set
+`ImportantFilePatterns: []` in `.github/PSModule.yml` to disable triggering regardless of the workflow input.
 
 Resolution order: settings file → workflow input → workflow input default values.
 

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ You can also pass patterns via the workflow input:
 ```yaml
 jobs:
   Process:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v1
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
     with:
       ImportantFilePatterns: |
         ^src/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Depending on the labels in the pull requests, the [workflow will result in diffe
     - [Scenario Matrix](#scenario-matrix)
     - [Important file change detection](#important-file-change-detection)
       - [Files that trigger releases](#files-that-trigger-releases)
-      - [Files that do NOT trigger releases](#files-that-do-not-trigger-releases)
+      - [Customizing important file patterns](#customizing-important-file-patterns)
       - [Behavior when no important files are changed](#behavior-when-no-important-files-are-changed)
   - [Configuration](#configuration)
     - [Example 1 - Defaults with Code Coverage target](#example-1---defaults-with-code-coverage-target)

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ the workflow's default patterns (`^src/` and `^README\.md$`) to be used — the 
 workflow input, so set `ImportantFilePatterns: []` in `.github/PSModule.yml` to disable triggering regardless of the
 workflow input.
 
-Resolution order: settings file → workflow input → hardcoded defaults.
+Resolution order: settings file → workflow input → workflow input default values.
 
 #### Behavior when no important files are changed
 


### PR DESCRIPTION
Repositories can now control which file changes trigger build, test, and publish stages by configuring the `ImportantFilePatterns` workflow input or settings file property. The default patterns (`^src/` and `^README\.md$`) remain unchanged for backward compatibility.

- Fixes #278

## New: Configurable release-triggering file patterns

The `ImportantFilePatterns` input is now available on the `workflow.yml` and `Get-Settings.yml` reusable workflows. Pass a newline-separated list of regex patterns to override the defaults:

```yaml
jobs:
  Process:
    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
    with:
      ImportantFilePatterns: |
        ^src/
        ^README\.md$
        ^examples/
```

To disable file-change triggering entirely, pass an empty string via the workflow input or set an empty list in `.github/PSModule.yml`:

```yaml
# In .github/PSModule.yml
ImportantFilePatterns: []
```

Resolution order: settings file → workflow input → workflow input default values.

## Changed: PR comment reflects configured patterns

The automated comment posted on PRs when no important files are changed now dynamically lists the configured patterns instead of a hardcoded table.

## Technical Details

- Added `ImportantFilePatterns` input (type: `string`, newline-separated) to both `.github/workflows/workflow.yml` and `.github/workflows/Get-Settings.yml` with explicit defaults (`^src/` and `^README\.md$`).
- Bumped `Get-PSModuleSettings` action reference from `v1.4.4` to `v1.5.0` which implements the settings file and action input support for this feature.
- Passed `ImportantFilePatterns` input through the reusable workflow chain to the `Get-PSModuleSettings` action step.
- Updated README documentation: new input in the workflow inputs table, new "Customizing important file patterns" section with YAML examples, updated settings file reference and example schema.