### PR TITLE
🪲 [Fix]: Super-linter can now post PR comment summaries

### DIFF
--- a/.github/workflows/Lint-Repository.yml
+++ b/.github/workflows/Lint-Repository.yml
@@ -9,8 +9,9 @@ on:
         required: true
 
 permissions:
-  contents: read  # to checkout the repository
-  statuses: write # to update the status of the workflow from linter
+  contents: read       # to checkout the repository
+  statuses: write      # to update the status of the workflow from linter
+  pull-requests: write # to post super-linter summary comments on PRs
 
 jobs:
   Lint-Repository:


### PR DESCRIPTION
Super-linter's inline PR comment summaries now appear when lint errors are found. Previously, the linter detected issues but silently failed to post the summary comment, requiring developers to navigate to the Actions log to see what went wrong.

- Fixes #307

## Fixed: Lint error summaries now visible directly on PRs

When super-linter detects markdown, YAML, or other linting issues, it posts a summary comment on the pull request for quick feedback. This was failing with a 403 error because the `Lint-Repository.yml` reusable workflow's `permissions:` block only granted `contents: read` and `statuses: write`, omitting the `pull-requests: write` permission needed by the GitHub Issues API to create comments.

The error looked like this in the Actions log:

```
[WARN] Failed to call GitHub API: curl: (22) The requested URL returned error: 403
[WARN] Failed to create GitHub issue comment
[WARN] Error while posting pull request summary
```

Lint failures are still correctly reported — only the inline PR comment was missing.

## Technical Details

- Added `pull-requests: write` to the `permissions:` block in `.github/workflows/Lint-Repository.yml`.
- When a reusable workflow defines its own `permissions:` block, it overrides (not inherits) the calling workflow's permissions. The parent workflows (`workflow.yml` and consumer repos) already grant `pull-requests: write`, but `Lint-Repository.yml` was restricting the `GITHUB_TOKEN` to a narrower scope.
- No other workflows or jobs are affected — the permission is scoped to the lint job only.