### PR TITLE
⚙️ [Maintenance]: Dependabot updates now target a dedicated branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions # See documentation for possible values
     directory: / # Location of package manifests
+    target-branch: dependabot/update-target
     labels:
       - dependencies
       - github-actions


### PR DESCRIPTION
Dependabot version update PRs now target the `dependabot/update-target` branch instead of `main`. This allows dependency updates to be batched and reviewed together before merging into the default branch, reducing noise on `main`.\n\n## Changed: Dependabot target branch\n\nAll future dependabot PRs for `github-actions` will be created against `dependabot/update-target` instead of `main`. Existing open dependabot PRs have been retargeted to this branch as well.\n\n## Technical Details\n\n- Added `target-branch: dependabot/update-target` to `.github/dependabot.yml` under the `github-actions` ecosystem entry.