### PR TITLE
[Patch]: Update GitHub Actions dependencies to latest pinned versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,13 @@ updates:
     directory: / # Location of package manifests
     labels:
       - dependencies
-      - github-actions
+      - github_actions
     schedule:
       interval: daily
     cooldown:
       default-days: 7
+    groups:
+      # Combine every GitHub Actions update into a single grouped pull request.
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/AfterAll-ModuleLocal.yml
+++ b/.github/workflows/AfterAll-ModuleLocal.yml
@@ -50,7 +50,7 @@ jobs:
       SETTINGS: ${{ inputs.Settings }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/BeforeAll-ModuleLocal.yml
+++ b/.github/workflows/BeforeAll-ModuleLocal.yml
@@ -50,7 +50,7 @@ jobs:
       Settings: ${{ inputs.Settings }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/Build-Docs.yml
+++ b/.github/workflows/Build-Docs.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Lint documentation
         id: super-linter
-        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
+        uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           RUN_LOCAL: true
           DEFAULT_BRANCH: main

--- a/.github/workflows/Build-Docs.yml
+++ b/.github/workflows/Build-Docs.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/Build-Module.yml
+++ b/.github/workflows/Build-Module.yml
@@ -24,7 +24,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/Build-Site.yml
+++ b/.github/workflows/Build-Site.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/Get-Settings.yml
+++ b/.github/workflows/Get-Settings.yml
@@ -60,7 +60,7 @@ jobs:
       Settings: ${{ steps.Get-Settings.outputs.Settings }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/Lint-Repository.yml
+++ b/.github/workflows/Lint-Repository.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Lint code base
         id: super-linter
-        uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
+        uses: super-linter/super-linter@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           DEFAULT_WORKSPACE: ${{ fromJson(env.Settings).WorkingDirectory }}

--- a/.github/workflows/Lint-Repository.yml
+++ b/.github/workflows/Lint-Repository.yml
@@ -21,7 +21,7 @@ jobs:
       Settings: ${{ inputs.Settings }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/Lint-SourceCode.yml
+++ b/.github/workflows/Lint-SourceCode.yml
@@ -21,7 +21,7 @@ jobs:
         include: ${{ fromJson(inputs.Settings).TestSuites.SourceCode }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint code base
-        uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
+        uses: super-linter/super-linter@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           VALIDATE_BIOME_FORMAT: false

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish module
-        uses: PSModule/Publish-PSModule@8917aed588dae1bd1aa2873b1caec1c50c20d255 # v2.2.4
+        uses: PSModule/Publish-PSModule@03c0f8b53d0367c85a0f121f98af9b40c817b0e3 # v3.0.0
         env:
           GH_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -24,7 +24,7 @@ jobs:
       SETTINGS: ${{ inputs.Settings }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/Test-Module.yml
+++ b/.github/workflows/Test-Module.yml
@@ -52,7 +52,7 @@ jobs:
         include: ${{ fromJson(inputs.Settings).TestSuites.PSModule }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -82,7 +82,7 @@ jobs:
         include: ${{ fromJson(inputs.Settings).TestSuites.PSModule }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/Test-ModuleLocal.yml
+++ b/.github/workflows/Test-ModuleLocal.yml
@@ -53,7 +53,7 @@ jobs:
         include: ${{ fromJson(inputs.Settings).TestSuites.Module }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/Test-SourceCode.yml
+++ b/.github/workflows/Test-SourceCode.yml
@@ -21,7 +21,7 @@ jobs:
         include: ${{ fromJson(inputs.Settings).TestSuites.SourceCode }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0


### PR DESCRIPTION
Consolidates the currently-passing Dependabot GitHub Actions updates into one change, so the pipeline moves to the latest action versions in a single release instead of separate bumps. It also configures Dependabot to group future GitHub Actions updates into one pull request, so this consolidated form happens automatically from now on.

**Superseded Dependabot PRs:** #351, #353, #354, #355 — Dependabot closes these automatically once this merges.

> ⚠️ **Build-PSModule v5.0.0 (#350) is intentionally excluded.** v5 makes `moduleVersion` a required input, which the current `Build-Module.yml` does not provide, so it fails CI (6 checks on #350's own PR too). Adopting it needs the "decide version before build" work in #342 and should ship with/after that PR. #350 stays open to track it.

## Updated GitHub Actions

| Action | From | To | Bump |
| --- | --- | --- | --- |
| actions/checkout | v6.0.2 | v7.0.0 | Major |
| PSModule/Publish-PSModule | v2.2.4 | v3.0.0 | Major |
| super-linter/super-linter | v8.6.0 | v8.7.0 | Minor |
| super-linter/super-linter/slim | v8.6.0 | v8.7.0 | Minor |

This bundle includes two major action upgrades, so it is labelled `Major` and cuts a major release of Process-PSModule on merge.

## Changed: Dependabot groups GitHub Actions updates

`.github/dependabot.yml` now groups all `github-actions` updates into a single grouped pull request via a `groups` block. The `github_actions` label is also corrected — it was `github-actions`, which does not match the repository label and was silently dropped by Dependabot.

## Technical Details

- Each bump is a cherry-pick of the original Dependabot commit, preserving authorship and the `Bump X from A to B` messages for a clean linear history.
- All bumps touch only `uses:` pins under `.github/workflows/`; no logic changes.
- Dependabot grouping added:

  ```yaml
  groups:
    github-actions:
      patterns:
        - "*"
  ```

  This groups every GitHub Actions ecosystem update (all semver levels) into one PR. To keep major bumps as separate PRs for individual review, add `update-types: ["minor", "patch"]` under the group — majors then continue to open on their own.
- No linked issue: this is Dependabot-driven maintenance; the superseded PRs above are the traceability.
