### PR TITLE
🪲 [Fix]: Restore correct release versioning in the publish pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,12 +19,3 @@ updates:
       github-actions:
         patterns:
           - "*"
-    ignore:
-      # Temporary: freeze major bumps of our own *-PSModule lifecycle actions
-      # until the version-calculation refactor (#326) lands. A premature major
-      # bump of Publish-PSModule (#358) broke the publish pipeline; this stops
-      # Dependabot from re-proposing that class of change until the refactor is
-      # in place and the actions can be adopted together.
-      - dependency-name: "PSModule/*-PSModule"
-        update-types:
-          - version-update:semver-major

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,12 @@ updates:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      # Temporary: freeze major bumps of our own *-PSModule lifecycle actions
+      # until the version-calculation refactor (#326) lands. A premature major
+      # bump of Publish-PSModule (#358) broke the publish pipeline; this stops
+      # Dependabot from re-proposing that class of change until the refactor is
+      # in place and the actions can be adopted together.
+      - dependency-name: "PSModule/*-PSModule"
+        update-types:
+          - version-update:semver-major

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           ModulePath: outputs/module
-          APIKey: ${{ secrets.APIKEY }}
+          APIKey: ${{ secrets.APIKey }}
           WhatIf: ${{ github.repository == 'PSModule/Process-PSModule' }}
           AutoCleanup: ${{ fromJson(inputs.Settings).Publish.Module.AutoCleanup }}
           AutoPatching: ${{ fromJson(inputs.Settings).Publish.Module.AutoPatching }}

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish module
-        uses: PSModule/Publish-PSModule@03c0f8b53d0367c85a0f121f98af9b40c817b0e3 # v3.0.0
+        uses: PSModule/Publish-PSModule@8917aed588dae1bd1aa2873b1caec1c50c20d255 # v2.2.4
         env:
           GH_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
The module publishing pipeline once again calculates and stamps the real release version before publishing, so consumer releases are versioned and tagged correctly instead of shipping the build-time placeholder. This reverts the premature `Publish-PSModule` major upgrade that left `main` in an inconsistent state.

- Relates to #326 (move version calculation ahead of the build step)
- Contains the regression introduced by #358

## Fixed: Releases are versioned correctly again

`Publish-PSModule` is pinned back to `v2.2.4`, which calculates the release version (from labels and tags) and stamps it into the module manifest at publish time. On `main`, `Build-PSModule` (v4) only stamps a `999.0.0` placeholder and does not compute the real version, and `Publish-PSModule` v3.0.0 is publish-only — it expects the manifest to already carry the final version. With v3.0.0 in place, nothing in the pipeline computed the real version, so a real consumer release would have published and tagged `999.0.0`. Reverting to `v2.2.4` restores the fully consistent old pipeline: Get-Settings → Build (v4, `999.0.0`) → Publish (v2.2.4, calculates + stamps).

Only the `Publish-PSModule` pin is reverted. The other action bumps from #358 (`actions/checkout` v7.0.0, `super-linter` v8.7.0) are left in place.

## Technical Details

- `.github/workflows/Publish-Module.yml`: `PSModule/Publish-PSModule` pin reverted `03c0f8b… # v3.0.0` → `8917aed… # v2.2.4`. This is the exact pin #358 replaced; no `with:` inputs changed — v2.2.4 consumes the version-calculation inputs the workflow already passes, whereas v3.0.0 silently ignored them.
- `.github/workflows/Publish-Module.yml`: normalized the `APIKey` action input from `secrets.APIKEY` to `secrets.APIKey` to match the `APIKey` secret declaration and the other workflows (`workflow.yml`, `Workflow-Test-*.yml`). GitHub Actions secret names are case-insensitive, so this is a consistency-only change with no behavioral effect (flagged during Copilot review).
- This is step 1 (containment) of #326. Follow-ups: release `Resolve-PSModuleVersion` with the #348 fix, then rebase and land PR #342 (Plan job + Build v5 + publish-only Publish) and re-pin the first-party actions together.
