### PR TITLE
🩹 [Patch]: Render group overview pages as section landing pages

### DIFF
--- a/.github/workflows/Build-Docs.yml
+++ b/.github/workflows/Build-Docs.yml
@@ -30,7 +30,7 @@ jobs:
           path: ${{ fromJson(inputs.Settings).WorkingDirectory }}/outputs/module
 
       - name: Document module
-        uses: PSModule/Document-PSModule@fb5d349fa6e6ff8277b2eaf32a588cd97b234525 # v1.0.17
+        uses: PSModule/Document-PSModule@349090c346feca4a7e5f51b6e57278a13ad52657 # v1.0.18
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           WorkingDirectory: ${{ fromJson(inputs.Settings).WorkingDirectory }}

--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ Key expectations:
 - Keep at least one exported function under `src/functions/public/` and corresponding tests in `tests/`.
 - Optional folders (`assemblies`, `formats`, `types`, `variables`, and others) are processed automatically when present.
 - Markdown files in `src/functions/public` subfolders become documentation pages alongside generated help.
+- A group's overview page (`<Category>/<Category>.md` named after the folder, or `<Category>/index.md`) becomes that group's section landing page in the docs navigation.
 - The build step compiles `src/` into a root module file and removes the original project layout from the artifact.
 - Documentation generation mirrors the `src/functions/public` hierarchy so help content always aligns with source.
 
@@ -1100,7 +1101,7 @@ How the module is built.
 │   │   └── public/                         # Public commands documented and tested
 │   │       ├── Category/                   # Optional: organize commands into categories
 │   │       │   ├── Get-CategoryCommand.ps1 # Command file within category
-│   │       │   └── Category.md             # Category overview merged into docs output
+│   │       │   └── Category.md             # Group overview -> section landing page (or index.md)
 │   │       ├── Get-PSModuleTest.ps1        # Example command captured by Microsoft.PowerShell.PlatyPS
 │   │       ├── New-PSModuleTest.ps1        # Example command exported and tested
 │   │       ├── Set-PSModuleTest.ps1        # Example command exported and tested


### PR DESCRIPTION
Module documentation now renders a command group's overview page as that group's **section landing page** — the content shown when the group is selected in the navigation — instead of a separate page nested under it. This is delivered by bumping the `Document-PSModule` action, and the behavior is documented in the repository and module-source structure guidance.

- Fixes #371

## Changed: Group overview pages are the section landing page

Bumped `PSModule/Document-PSModule` to v1.0.18 in `Build-Docs.yml`. v1.0.18 publishes a group's overview page as the section index (`/Functions/<Group>/`) rather than a page nested under the group. Authors can name the overview after its folder (`<Category>/<Category>.md`) or provide `<Category>/index.md` directly; either becomes the section landing page.

## Changed: Documentation

Documented the behavior in `README.md`: added a bullet under the repository expectations and updated the `Category.md` annotation in the module source-structure tree.

## Technical Details

- `.github/workflows/Build-Docs.yml`: `Document-PSModule@fb5d349 # v1.0.17` -> `@349090c # v1.0.18`.
- `main` already carries v1.0.17 (install built modules at their real version) from #342; this PR advances the pin to v1.0.18, which delivers the section-index behavior.
- The site config already enables `navigation.indexes`, so no `mkdocs.yml` change is required.