### PR TITLE
🪲 [Fix]: Resolve the current version on non-PR runs (bump Resolve-PSModuleVersion to v1.1.5)

### DIFF
--- a/.github/workflows/Plan.yml
+++ b/.github/workflows/Plan.yml
@@ -85,7 +85,7 @@ jobs:
           ImportantFilePatterns: ${{ inputs.ImportantFilePatterns }}
 
       - name: Resolve-Version
-        uses: PSModule/Resolve-PSModuleVersion@8d1dac7f326a45ba08060c1e24a5dd6f6f00b3ab # v1.1.4
+        uses: PSModule/Resolve-PSModuleVersion@6a59a88d3a3b1e7710c4d1d91fcc684cd4da3667 # v1.1.5
         id: Resolve-Version
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The `Plan` job no longer fails on `schedule` and `workflow_dispatch` events. `Resolve-PSModuleVersion` is bumped to `v1.1.5`, which resolves the current published version on non–pull-request events instead of throwing.

- Fixes #373

## Fixed: non–pull-request runs (schedule / workflow_dispatch)

Since v6.1.0 the `Plan` job runs `Resolve-Version` on every event, and the action threw `"...must be run from a pull_request event"` on non-PR events — failing the whole run (every job `needs: Plan`). `Resolve-PSModuleVersion` `v1.1.5` (PSModule/Resolve-PSModuleVersion#10) fixes this at the source: on a non-PR event it returns the current published version — no bump, no prerelease, nothing published — floored at `0.0.0` for a module that has never been released. Pull-request and merge-to-default-branch behavior is unchanged: labels drive the bump (patch default), and the version preview on regular PRs is retained.

## Technical Details

- `.github/workflows/Plan.yml`: bump the `Resolve-Version` pin `8d1dac7` (`v1.1.4`) → `6a59a88` (`v1.1.5`). One-line change — no `Plan` gate or `Test-ModuleLocal` fallback is needed, because v1.1.5 always populates `Settings.Module.Version` on non-PR events.
- This supersedes this PR's earlier `Plan.yml` gate + `999.0.0` fallback approach, replaced by the root-cause fix in the shared action.
- Validated: a `workflow_dispatch` self-test run on this branch completes (previously failed at `Plan`); the PR self-test resolves a version as before.
