### PR TITLE
🩹 [Patch]: Bump Invoke-ScriptAnalyzer to v5.0.0 and Test-PSModule to v3.0.14

### DIFF
--- a/.github/workflows/Lint-SourceCode.yml
+++ b/.github/workflows/Lint-SourceCode.yml
@@ -26,12 +26,12 @@ jobs:
           persist-credentials: false
 
       - name: Lint-SourceCode
-        uses: PSModule/Invoke-ScriptAnalyzer@6aeb1bc093b89f9b15c2ac3e5f9ef9e0879dc755 # v4.1.3
+        uses: PSModule/Invoke-ScriptAnalyzer@4d633e4df1f1fa575949a328839d33c3a0838765 # v5.0.0
         with:
           Debug: ${{ fromJson(inputs.Settings).Debug }}
-          Prerelease: ${{ fromJson(inputs.Settings).Prerelease }}
+          GitHubPrerelease: ${{ fromJson(inputs.Settings).Prerelease }}
+          GitHubVersion: ${{ fromJson(inputs.Settings).Version }}
           Verbose: ${{ fromJson(inputs.Settings).Verbose }}
-          Version: ${{ fromJson(inputs.Settings).Version }}
           Path: src
           WorkingDirectory: ${{ fromJson(inputs.Settings).WorkingDirectory }}
           TestResult_Enabled: true

--- a/.github/workflows/Test-Module.yml
+++ b/.github/workflows/Test-Module.yml
@@ -32,7 +32,7 @@ jobs:
           path: ${{ fromJson(inputs.Settings).WorkingDirectory }}/outputs/module
 
       - name: Test-Module
-        uses: PSModule/Test-PSModule@25c9cd89954d558360e5917efbd4dea4ca894144 # v3.0.13
+        uses: PSModule/Test-PSModule@902c5e50774e6606ccf41c125a1fe89f783c1149 # v3.0.14
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           Debug: ${{ fromJson(inputs.Settings).Debug }}

--- a/.github/workflows/Test-Module.yml
+++ b/.github/workflows/Test-Module.yml
@@ -62,13 +62,13 @@ jobs:
           path: ${{ fromJson(inputs.Settings).WorkingDirectory }}/outputs/module
 
       - name: Lint-Module
-        uses: PSModule/Invoke-ScriptAnalyzer@6aeb1bc093b89f9b15c2ac3e5f9ef9e0879dc755 # v4.1.3
+        uses: PSModule/Invoke-ScriptAnalyzer@4d633e4df1f1fa575949a328839d33c3a0838765 # v5.0.0
         with:
           Path: outputs/module
           Debug: ${{ fromJson(inputs.Settings).Debug }}
-          Prerelease: ${{ fromJson(inputs.Settings).Prerelease }}
+          GitHubPrerelease: ${{ fromJson(inputs.Settings).Prerelease }}
+          GitHubVersion: ${{ fromJson(inputs.Settings).Version }}
           Verbose: ${{ fromJson(inputs.Settings).Verbose }}
-          Version: ${{ fromJson(inputs.Settings).Version }}
           WorkingDirectory: ${{ fromJson(inputs.Settings).WorkingDirectory }}
           TestResult_Enabled: true
           TestResult_TestSuiteName: PSModuleLint-Module-${{ runner.os }}

--- a/.github/workflows/Test-SourceCode.yml
+++ b/.github/workflows/Test-SourceCode.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Test-SourceCode
-        uses: PSModule/Test-PSModule@25c9cd89954d558360e5917efbd4dea4ca894144 # v3.0.13
+        uses: PSModule/Test-PSModule@902c5e50774e6606ccf41c125a1fe89f783c1149 # v3.0.14
         with:
           Debug: ${{ fromJson(inputs.Settings).Debug }}
           Prerelease: ${{ fromJson(inputs.Settings).Prerelease }}


### PR DESCRIPTION
Brings Process-PSModule's lint/test action dependencies to their latest releases: `PSModule/Invoke-ScriptAnalyzer` v4.1.3 → v5.0.0 and `PSModule/Test-PSModule` v3.0.13 → v3.0.14. Both preserve the reusable workflow's `Settings.Version`/`Settings.Prerelease` contract for consumers.

## Changed: Invoke-ScriptAnalyzer upgraded to v5.0.0

Invoke-ScriptAnalyzer v5.0.0 is a major release that repurposed its `Version`/`Prerelease` inputs to select the **PSScriptAnalyzer** module version and moved the GitHub bootstrap-module controls to `GitHubVersion`/`GitHubPrerelease`.

The `Lint-SourceCode` and `Lint-Module` steps pass `Settings.Version`/`Settings.Prerelease`, which in this ecosystem select the **GitHub module** (the same values feed the Invoke-Pester and GitHub-Script steps). They are now wired to Invoke-ScriptAnalyzer's `GitHubVersion`/`GitHubPrerelease`, so those settings keep controlling the GitHub module exactly as before. No change to the `Settings` contract.

With v5, the action also installs PSScriptAnalyzer itself (latest, since its `Version` is left unset) instead of relying on the runner's preinstalled copy — so consumer linting now runs against the latest PSScriptAnalyzer.

## Changed: Test-PSModule upgraded to v3.0.14

Patch release; Test-PSModule v3.0.14 (which internally bumped Invoke-Pester to v5.1.0) preserves its own `Version`/`Prerelease` (GitHub module) contract, so the `Test-SourceCode` and `Test-Module` steps need only a SHA update — no input remap.

## Technical Details

- `Lint-SourceCode.yml`, `Test-Module.yml`: `Invoke-ScriptAnalyzer` `6aeb1bc` (v4.1.3) → `4d633e4` (v5.0.0); remapped `Version` → `GitHubVersion`, `Prerelease` → `GitHubPrerelease`.
- `Test-Module.yml`, `Test-SourceCode.yml`: `Test-PSModule` `25c9cd8` (v3.0.13) → `902c5e5` (v3.0.14).
- Pester and PSScriptAnalyzer versions left at the v5 defaults (latest); not wired to any `Settings` key.
- Scope: the Invoke-Pester step (`Test-ModuleLocal.yml`, still v4.2.6) is intentionally untouched.
- Label note: the `Settings` contract is preserved (hence `Patch`), but consumer linting now runs against the latest PSScriptAnalyzer — bump to `Minor` if you'd rather signal that behavior change.

Release notes: [Invoke-ScriptAnalyzer v5.0.0](https://github.com/PSModule/Invoke-ScriptAnalyzer/releases/tag/v5.0.0)
