### PR TITLE
🪲 [Fix]: TestData keys reach setup and teardown phases

### DIFF
--- a/.github/actions/Expose-TestData/action.yml
+++ b/.github/actions/Expose-TestData/action.yml
@@ -1,0 +1,24 @@
+name: Expose-TestData
+description: Exposes caller-provided Process-PSModule TestData as environment variables.
+author: PSModule
+branding:
+  icon: unlock
+  color: white
+
+inputs:
+  TestData:
+    description: |
+      Optional single-line JSON object with 'secrets' and 'variables' maps. Entries are validated by
+      Import-TestData and exported to GITHUB_ENV for later steps in the same job.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Expose caller-provided test data
+      shell: pwsh
+      env:
+        PSMODULE_TEST_DATA: ${{ inputs.TestData }}
+      run: |
+        Import-TestData

--- a/.github/workflows/AfterAll-ModuleLocal.yml
+++ b/.github/workflows/AfterAll-ModuleLocal.yml
@@ -43,11 +43,9 @@ jobs:
         uses: ./_wf/.github/actions/Install-PSModuleHelpers
 
       - name: Expose caller-provided test data
-        shell: pwsh
-        env:
-          PSMODULE_TEST_DATA: ${{ secrets.TestData }}
-        run: |
-          Import-TestData
+        uses: ./_wf/.github/actions/Expose-TestData
+        with:
+          TestData: ${{ secrets.TestData }}
 
       - name: Run AfterAll Teardown Scripts
         if: always()

--- a/.github/workflows/BeforeAll-ModuleLocal.yml
+++ b/.github/workflows/BeforeAll-ModuleLocal.yml
@@ -43,11 +43,9 @@ jobs:
         uses: ./_wf/.github/actions/Install-PSModuleHelpers
 
       - name: Expose caller-provided test data
-        shell: pwsh
-        env:
-          PSMODULE_TEST_DATA: ${{ secrets.TestData }}
-        run: |
-          Import-TestData
+        uses: ./_wf/.github/actions/Expose-TestData
+        with:
+          TestData: ${{ secrets.TestData }}
 
       - name: Run BeforeAll Setup Scripts
         uses: PSModule/GitHub-Script@8083ec1f733f00357ee4d0db0c6056686e483bc0 # v1.9.0

--- a/.github/workflows/Test-ModuleLocal.yml
+++ b/.github/workflows/Test-ModuleLocal.yml
@@ -54,11 +54,9 @@ jobs:
         uses: ./_wf/.github/actions/Install-PSModuleHelpers
 
       - name: Expose caller-provided test data
-        shell: pwsh
-        env:
-          PSMODULE_TEST_DATA: ${{ secrets.TestData }}
-        run: |
-          Import-TestData
+        uses: ./_wf/.github/actions/Expose-TestData
+        with:
+          TestData: ${{ secrets.TestData }}
 
       - name: Import-Module
         id: import-module

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,10 @@ on:
           $env:<name>. Values under "secrets" are masked in the logs; values under "variables" are not.
           Build it from secrets.<name> / vars.<name> in the calling workflow (see the README). Keep it
           on a single line so GitHub registers one mask for the whole value. Omit it when the module
-          needs no test data.
+          needs no test data. The same keys are exported before BeforeAll-ModuleLocal,
+          Test-ModuleLocal, and AfterAll-ModuleLocal run. If setup or teardown scripts see a missing
+          key, confirm the caller explicitly maps a TestData JSON value; secrets: inherit only passes
+          an already-created TestData secret and does not build JSON from individual secrets.
         required: false
     inputs:
       SettingsPath:

--- a/README.md
+++ b/README.md
@@ -9,3 +9,30 @@ The full documentation lives on the MSX / Docs site:
 📖 **[Process-PSModule documentation](https://msxorg.github.io/docs/Frameworks/Process-PSModule/)**
 
 It covers getting started, the pipeline stages, usage, configuration, repository structure, and the principles behind the framework.
+
+## TestData phase parity
+
+Module-local setup, test, and teardown phases use the same `TestData` contract. Values under
+`secrets` are masked and values under `variables` are exported unmasked, and every key is available
+as `$env:<name>` in all three phases:
+
+- `BeforeAll-ModuleLocal` (`tests/BeforeAll.ps1`)
+- `Test-ModuleLocal` (Pester module tests)
+- `AfterAll-ModuleLocal` (`tests/AfterAll.ps1`)
+
+Pass `TestData` as a single-line JSON object from the calling workflow:
+
+```yaml
+jobs:
+  Process-PSModule:
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v6
+    secrets:
+      APIKey: ${{ secrets.APIKey }}
+      TestData: >-
+        { "secrets": { "TEST_TOKEN": "${{ secrets.TEST_TOKEN }}" },
+          "variables": { "TEST_OWNER": ${{ toJSON(vars.TEST_OWNER) }} } }
+```
+
+If a key is missing in setup or teardown, verify that the caller explicitly maps `TestData` as JSON.
+`secrets: inherit` only passes a repository or environment secret already named `TestData`; it does not
+automatically build the JSON object from individual secrets.

--- a/README.md
+++ b/README.md
@@ -9,30 +9,3 @@ The full documentation lives on the MSX / Docs site:
 📖 **[Process-PSModule documentation](https://msxorg.github.io/docs/Frameworks/Process-PSModule/)**
 
 It covers getting started, the pipeline stages, usage, configuration, repository structure, and the principles behind the framework.
-
-## TestData phase parity
-
-Module-local setup, test, and teardown phases use the same `TestData` contract. Values under
-`secrets` are masked and values under `variables` are exported unmasked, and every key is available
-as `$env:<name>` in all three phases:
-
-- `BeforeAll-ModuleLocal` (`tests/BeforeAll.ps1`)
-- `Test-ModuleLocal` (Pester module tests)
-- `AfterAll-ModuleLocal` (`tests/AfterAll.ps1`)
-
-Pass `TestData` as a single-line JSON object from the calling workflow:
-
-```yaml
-jobs:
-  Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v6
-    secrets:
-      APIKey: ${{ secrets.APIKey }}
-      TestData: >-
-        { "secrets": { "TEST_TOKEN": "${{ secrets.TEST_TOKEN }}" },
-          "variables": { "TEST_OWNER": ${{ toJSON(vars.TEST_OWNER) }} } }
-```
-
-If a key is missing in setup or teardown, verify that the caller explicitly maps `TestData` as JSON.
-`secrets: inherit` only passes a repository or environment secret already named `TestData`; it does not
-automatically build the JSON object from individual secrets.

--- a/tests/srcTestRepo/tests/AfterAll.ps1
+++ b/tests/srcTestRepo/tests/AfterAll.ps1
@@ -1,6 +1,8 @@
 ﻿Write-Warning "=== AFTERALL TEARDOWN SCRIPT EXECUTING ==="
 Write-Warning "Tearing down test environment..."
 
+. "$PSScriptRoot/TestData.Assertions.ps1"
+
 # Example teardown tasks:
 # - Clean up test infrastructure
 # - Remove test data

--- a/tests/srcTestRepo/tests/BeforeAll.ps1
+++ b/tests/srcTestRepo/tests/BeforeAll.ps1
@@ -1,6 +1,8 @@
 ﻿Write-Warning "=== BEFOREALL SETUP SCRIPT EXECUTING ==="
 Write-Warning "Setting up test environment..."
 
+. "$PSScriptRoot/TestData.Assertions.ps1"
+
 # Example setup tasks:
 # - Deploy test infrastructure
 # - Download test data

--- a/tests/srcTestRepo/tests/TestData.Assertions.ps1
+++ b/tests/srcTestRepo/tests/TestData.Assertions.ps1
@@ -1,0 +1,16 @@
+$expectedTestData = @{
+    PSMODULE_TEST_SINGLELINE_SECRET = 'psmodule-public-nonsecret-test-fixture-single-line'
+    PSMODULE_TEST_VARIABLE          = 'psmodule-public-nonsecret-test-variable'
+}
+
+foreach ($entry in $expectedTestData.GetEnumerator()) {
+    $actual = [System.Environment]::GetEnvironmentVariable($entry.Key)
+    if ([string]::IsNullOrEmpty($actual)) {
+        throw "TestData key '$($entry.Key)' is not available in the current module-local phase."
+    }
+    if ($actual -cne $entry.Value) {
+        throw "TestData key '$($entry.Key)' has an unexpected value in the current module-local phase."
+    }
+}
+
+Write-Warning 'TestData secret and variable fixtures are available in this module-local phase.'

--- a/tests/srcWithManifestTestRepo/tests/AfterAll.ps1
+++ b/tests/srcWithManifestTestRepo/tests/AfterAll.ps1
@@ -1,6 +1,8 @@
 ﻿Write-Warning "=== AFTERALL TEARDOWN SCRIPT (Environments) EXECUTING ==="
 Write-Warning "Tearing down test environment for Environments..."
 
+. "$PSScriptRoot/TestData.Assertions.ps1"
+
 # Example teardown tasks for Environments directory:
 Write-Warning "Cleaning up Environments test environment..."
 

--- a/tests/srcWithManifestTestRepo/tests/BeforeAll.ps1
+++ b/tests/srcWithManifestTestRepo/tests/BeforeAll.ps1
@@ -1,6 +1,8 @@
 ﻿Write-Warning "=== BEFOREALL SETUP SCRIPT EXECUTING ==="
 Write-Warning "Setting up test environment..."
 
+. "$PSScriptRoot/TestData.Assertions.ps1"
+
 # Example setup tasks for test environment:
 Write-Warning "Initializing test environment..."
 

--- a/tests/srcWithManifestTestRepo/tests/TestData.Assertions.ps1
+++ b/tests/srcWithManifestTestRepo/tests/TestData.Assertions.ps1
@@ -1,0 +1,16 @@
+$expectedTestData = @{
+    PSMODULE_TEST_SINGLELINE_SECRET = 'psmodule-public-nonsecret-test-fixture-single-line'
+    PSMODULE_TEST_VARIABLE          = 'psmodule-public-nonsecret-test-variable'
+}
+
+foreach ($entry in $expectedTestData.GetEnumerator()) {
+    $actual = [System.Environment]::GetEnvironmentVariable($entry.Key)
+    if ([string]::IsNullOrEmpty($actual)) {
+        throw "TestData key '$($entry.Key)' is not available in the current module-local phase."
+    }
+    if ($actual -cne $entry.Value) {
+        throw "TestData key '$($entry.Key)' has an unexpected value in the current module-local phase."
+    }
+}
+
+Write-Warning 'TestData secret and variable fixtures are available in this module-local phase.'


### PR DESCRIPTION
TestData values now reach every module-local phase through the same export path. Setup scripts, module tests, and teardown scripts can rely on identical environment variable names for caller-provided secrets and variables, with secret masking preserved.

- Fixes #386

## Fixed: Setup and teardown scripts receive TestData keys

`BeforeAll-ModuleLocal`, `Test-ModuleLocal`, and `AfterAll-ModuleLocal` now all call the same local `Expose-TestData` action after installing the shared helper module. This keeps TestData parsing, validation, masking, and `GITHUB_ENV` export behavior identical before each phase runs.

Callers continue to use the existing `TestData` workflow secret; no interface change is required.

## Changed: TestData phase parity is documented

The README now states that the same TestData keys are available in setup, test, and teardown phases, and includes troubleshooting guidance for callers that use `secrets: inherit` without explicitly creating a `TestData` JSON payload.

## Technical Details

- Added `.github/actions/Expose-TestData/action.yml` as the single workflow step wrapper around `Import-TestData`.
- Updated `BeforeAll-ModuleLocal.yml`, `Test-ModuleLocal.yml`, and `AfterAll-ModuleLocal.yml` to use the shared action.
- Added fixture assertions to both workflow test repositories so `PSMODULE_TEST_SINGLELINE_SECRET` and `PSMODULE_TEST_VARIABLE` are checked in `BeforeAll.ps1`, Pester tests, and `AfterAll.ps1`.
- Implementation plan progress: core shared export path, parity validation, setup/teardown regression coverage, and README guidance are complete.
- Local validation: helper test scripts passed; setup/teardown fixture assertions passed for both test repositories; touched workflow files passed actionlint with the repository's known `job.workflow_repository`/`job.workflow_sha` context warnings ignored.
