### PR TITLE
⚙️ [Maintenance]: Add repository agent onboarding files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Follow the instructions in [AGENTS.md](../AGENTS.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agents
+
+This repository contains [Process-PSModule](https://msxorg.github.io/docs/Frameworks/Process-PSModule/), the PSModule automation workflow framework.
+
+## Start here
+
+1. Read this file, then [README.md](README.md) for repository purpose and scope.
+2. Read the [PSModule documentation](https://psmodule.io/docs) for framework-level standards.
+3. Read the [MSX documentation](https://msxorg.github.io/docs) for organization-level principles and guidance.
+
+## Working in this repository
+
+- Keep guidance and examples consistent with the documented framework behavior.
+- Prefer explicit, deterministic automation patterns in CI/CD changes.
+- Treat tests and sample repositories under `tests/` as contract coverage for workflow behavior.
+
+## The rule
+
+This file points; it never defines. Standards and process belong to canonical docs and should be linked, not restated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
This PR splits the agent-onboarding topic out of PSModule/docs PR #61 into the Process-PSModule repository.\n\n## Included\n- Add AGENTS.md\n- Add CLAUDE.md with @AGENTS.md import\n- Add .github/copilot-instructions.md pointing to AGENTS.md\n\n## Why\nEach repository should carry its own onboarding guidance and not rely on org-level fallback files.\n\n## Traceability\n- Related: https://github.com/PSModule/docs/pull/61\n