### PR TITLE
🩹 [Patch]: Prerelease cleanup no longer depends on module artifact

### DIFF
--- a/.github/actions/Cleanup-PSModulePrereleases/action.yml
+++ b/.github/actions/Cleanup-PSModulePrereleases/action.yml
@@ -1,0 +1,34 @@
+name: Cleanup-PSModulePrereleases
+description: Cleanup prerelease GitHub releases associated with the current pull request branch.
+author: PSModule
+
+inputs:
+  AutoCleanup:
+    description: Control whether to automatically delete prerelease tags.
+    required: false
+    default: 'true'
+  WhatIf:
+    description: If specified, the action will only log the changes it would make.
+    required: false
+    default: 'false'
+  WorkingDirectory:
+    description: The working directory where the script will run from.
+    required: false
+    default: '.'
+
+runs:
+  using: composite
+  steps:
+    - name: Install-PSModule
+      uses: ./_wf/.github/actions/Install-PSModule
+
+    - name: Cleanup Prereleases
+      if: inputs.AutoCleanup == 'true' || inputs.WhatIf == 'true'
+      shell: pwsh
+      working-directory: ${{ inputs.WorkingDirectory }}
+      env:
+        PSMODULE_CLEANUP_PSMODULEPRERELEASES_INPUT_WhatIf: ${{ inputs.WhatIf }}
+        PSMODULE_CLEANUP_PSMODULEPRERELEASES_CONTEXT_ReleaseTag: ${{ env.PSMODULE_PUBLISH_PSMODULE_CONTEXT_ReleaseTag }}
+      run: |
+        # Cleanup prerelease tags
+        ${{ github.action_path }}/src/cleanup.ps1

--- a/.github/actions/Cleanup-PSModulePrereleases/src/cleanup.ps1
+++ b/.github/actions/Cleanup-PSModulePrereleases/src/cleanup.ps1
@@ -7,7 +7,7 @@ Import-Module -Name 'Helpers' -Force
 
 #region Load inputs
 LogGroup 'Load inputs' {
-    $whatIf = $env:PSMODULE_PUBLISH_PSMODULE_INPUT_WhatIf -eq 'true'
+    $whatIf = $env:PSMODULE_CLEANUP_PSMODULEPRERELEASES_INPUT_WhatIf -eq 'true'
 
     $githubEventJson = Get-Content -Raw $env:GITHUB_EVENT_PATH
     $githubEvent = $githubEventJson | ConvertFrom-Json
@@ -27,7 +27,7 @@ LogGroup 'Load inputs' {
     Write-Host "Prerelease name:  [$prereleaseName]"
     Write-Host "WhatIf:           [$whatIf]"
 
-    $publishedReleaseTag = $env:PSMODULE_PUBLISH_PSMODULE_CONTEXT_ReleaseTag
+    $publishedReleaseTag = $env:PSMODULE_CLEANUP_PSMODULEPRERELEASES_CONTEXT_ReleaseTag
     if (-not [string]::IsNullOrWhiteSpace($publishedReleaseTag)) {
         Write-Host "Published tag:    [$publishedReleaseTag] (excluded from cleanup)"
     }

--- a/.github/actions/Publish-PSModule/action.yml
+++ b/.github/actions/Publish-PSModule/action.yml
@@ -7,20 +7,12 @@ inputs:
     description: Name of the module to publish.
     required: false
   ModulePath:
-    description: Path to the folder containing the <Name>/ module subdirectory from Build-PSModule. Required only when ReleaseType is not None.
+    description: Path to the folder containing the <Name>/ module subdirectory from Build-PSModule.
     required: false
     default: outputs/module
-  ReleaseType:
-    description: Resolved release type from settings (Release, Prerelease, None). Used to control prerelease cleanup behavior.
-    required: false
-    default: None
   APIKey:
     description: PowerShell Gallery API Key.
     required: true
-  AutoCleanup:
-    description: Control whether to automatically delete the prerelease tags after the stable release is created.
-    required: false
-    default: 'true'
   WhatIf:
     description: If specified, the action will only log the changes it would make, but will not actually create or delete any releases or tags.
     required: false
@@ -58,14 +50,12 @@ runs:
         Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
     - name: Download module artifact
-      if: inputs.ReleaseType != 'None'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.ArtifactName }}
         path: ${{ inputs.ModulePath }}
 
     - name: Publish Module
-      if: inputs.ReleaseType != 'None'
       shell: pwsh
       working-directory: ${{ inputs.WorkingDirectory }}
       env:
@@ -77,14 +67,3 @@ runs:
         PSMODULE_PUBLISH_PSMODULE_INPUT_UsePRTitleAsReleaseName: ${{ inputs.UsePRTitleAsReleaseName }}
         PSMODULE_PUBLISH_PSMODULE_INPUT_UsePRTitleAsNotesHeading: ${{ inputs.UsePRTitleAsNotesHeading }}
       run: ${{ github.action_path }}/src/publish.ps1
-
-    - name: Cleanup Prereleases
-      if: inputs.ReleaseType != 'Prerelease' && (inputs.AutoCleanup == 'true' || inputs.WhatIf == 'true')
-      shell: pwsh
-      working-directory: ${{ inputs.WorkingDirectory }}
-      env:
-        PSMODULE_PUBLISH_PSMODULE_INPUT_WhatIf: ${{ inputs.WhatIf }}
-        PSMODULE_PUBLISH_PSMODULE_CONTEXT_ReleaseTag: ${{ env.PSMODULE_PUBLISH_PSMODULE_CONTEXT_ReleaseTag }}
-      run: |
-        # Cleanup prerelease tags
-        ${{ github.action_path }}/src/cleanup.ps1

--- a/.github/actions/Publish-PSModule/action.yml
+++ b/.github/actions/Publish-PSModule/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: Path to the folder containing the <Name>/ module subdirectory from Build-PSModule.
     required: false
     default: outputs/module
-  CreateRelease:
-    description: When true, downloads the module artifact and runs publish.ps1 (PowerShell Gallery + GitHub Release flow).
-    required: false
-    default: 'false'
   ReleaseType:
     description: Resolved release type from settings (Release, Prerelease, None). Used to control prerelease cleanup behavior.
     required: false
@@ -58,14 +54,14 @@ runs:
         Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
     - name: Download module artifact
-      if: inputs.CreateRelease == 'true'
+      if: inputs.ReleaseType != 'None'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.ArtifactName }}
         path: ${{ inputs.ModulePath }}
 
     - name: Publish Module
-      if: inputs.CreateRelease == 'true'
+      if: inputs.ReleaseType != 'None'
       shell: pwsh
       working-directory: ${{ inputs.WorkingDirectory }}
       env:

--- a/.github/actions/Publish-PSModule/action.yml
+++ b/.github/actions/Publish-PSModule/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: Path to the folder containing the <Name>/ module subdirectory from Build-PSModule.
     required: false
     default: outputs/module
+  CreateRelease:
+    description: When true, downloads the module artifact and runs publish.ps1 (PowerShell Gallery + GitHub Release flow).
+    required: false
+    default: 'false'
+  ReleaseType:
+    description: Resolved release type from settings (Release, Prerelease, None). Used to control prerelease cleanup behavior.
+    required: false
+    default: None
   APIKey:
     description: PowerShell Gallery API Key.
     required: true
@@ -50,12 +58,14 @@ runs:
         Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
     - name: Download module artifact
+      if: inputs.CreateRelease == 'true'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.ArtifactName }}
         path: ${{ inputs.ModulePath }}
 
     - name: Publish Module
+      if: inputs.CreateRelease == 'true'
       shell: pwsh
       working-directory: ${{ inputs.WorkingDirectory }}
       env:

--- a/.github/actions/Publish-PSModule/action.yml
+++ b/.github/actions/Publish-PSModule/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: Path to the folder containing the <Name>/ module subdirectory from Build-PSModule.
     required: false
     default: outputs/module
-  ReleaseType:
-    description: Resolved release type from settings (Release, Prerelease, None). Used to control prerelease cleanup behavior.
-    required: false
-    default: None
   APIKey:
     description: PowerShell Gallery API Key.
     required: true
@@ -54,14 +50,12 @@ runs:
         Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
     - name: Download module artifact
-      if: inputs.ReleaseType != 'None'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.ArtifactName }}
         path: ${{ inputs.ModulePath }}
 
     - name: Publish Module
-      if: inputs.ReleaseType != 'None'
       shell: pwsh
       working-directory: ${{ inputs.WorkingDirectory }}
       env:

--- a/.github/actions/Publish-PSModule/action.yml
+++ b/.github/actions/Publish-PSModule/action.yml
@@ -7,9 +7,17 @@ inputs:
     description: Name of the module to publish.
     required: false
   ModulePath:
-    description: Path to the folder containing the <Name>/ module subdirectory from Build-PSModule. A module artifact must exist before invoking this action.
+    description: Path to the folder containing the <Name>/ module subdirectory from Build-PSModule. Required only when CreateRelease is true.
     required: false
     default: outputs/module
+  CreateRelease:
+    description: When true, downloads the module artifact and runs publish.ps1 (PowerShell Gallery + GitHub Release flow).
+    required: false
+    default: 'false'
+  ReleaseType:
+    description: Resolved release type from settings (Release, Prerelease, None). Used to control prerelease cleanup behavior.
+    required: false
+    default: None
   APIKey:
     description: PowerShell Gallery API Key.
     required: true
@@ -54,12 +62,14 @@ runs:
         Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
     - name: Download module artifact
+      if: inputs.CreateRelease == 'true'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.ArtifactName }}
         path: ${{ inputs.ModulePath }}
 
     - name: Publish Module
+      if: inputs.CreateRelease == 'true'
       shell: pwsh
       working-directory: ${{ inputs.WorkingDirectory }}
       env:
@@ -73,7 +83,7 @@ runs:
       run: ${{ github.action_path }}/src/publish.ps1
 
     - name: Cleanup Prereleases
-      if: env.PSMODULE_PUBLISH_PSMODULE_CONTEXT_IsPrerelease != 'true' && (inputs.AutoCleanup == 'true' || inputs.WhatIf == 'true')
+      if: inputs.ReleaseType != 'Prerelease' && (inputs.AutoCleanup == 'true' || inputs.WhatIf == 'true')
       shell: pwsh
       working-directory: ${{ inputs.WorkingDirectory }}
       env:

--- a/.github/actions/Publish-PSModule/action.yml
+++ b/.github/actions/Publish-PSModule/action.yml
@@ -7,13 +7,9 @@ inputs:
     description: Name of the module to publish.
     required: false
   ModulePath:
-    description: Path to the folder containing the <Name>/ module subdirectory from Build-PSModule. Required only when CreateRelease is true.
+    description: Path to the folder containing the <Name>/ module subdirectory from Build-PSModule. Required only when ReleaseType is not None.
     required: false
     default: outputs/module
-  CreateRelease:
-    description: When true, downloads the module artifact and runs publish.ps1 (PowerShell Gallery + GitHub Release flow).
-    required: false
-    default: 'false'
   ReleaseType:
     description: Resolved release type from settings (Release, Prerelease, None). Used to control prerelease cleanup behavior.
     required: false
@@ -62,14 +58,14 @@ runs:
         Install-PSResource -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -TrustRepository
 
     - name: Download module artifact
-      if: inputs.CreateRelease == 'true'
+      if: inputs.ReleaseType != 'None'
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.ArtifactName }}
         path: ${{ inputs.ModulePath }}
 
     - name: Publish Module
-      if: inputs.CreateRelease == 'true'
+      if: inputs.ReleaseType != 'None'
       shell: pwsh
       working-directory: ${{ inputs.WorkingDirectory }}
       env:

--- a/.github/actions/Publish-PSModule/src/publish.ps1
+++ b/.github/actions/Publish-PSModule/src/publish.ps1
@@ -140,9 +140,7 @@ LogGroup 'Resolve version from manifest' {
         PRHeadRef        = $prHeadRef
     } | Format-List | Out-String
 
-    # Expose publish context to subsequent steps so the cleanup step can gate on release type.
-    $envLine = "PSMODULE_PUBLISH_PSMODULE_CONTEXT_IsPrerelease=$($createPrerelease.ToString().ToLower())"
-    $envLine | Out-File -Path $env:GITHUB_ENV -Append -Encoding utf8NoBOM
+    # Expose release tag to subsequent steps so cleanup can exclude the just-published tag.
     "PSMODULE_PUBLISH_PSMODULE_CONTEXT_ReleaseTag=$releaseTag" | Out-File -Path $env:GITHUB_ENV -Append -Encoding utf8NoBOM
 }
 #endregion Resolve version from manifest

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           ModulePath: outputs/module
+          CreateRelease: ${{ fromJson(inputs.Settings).Module.CreateRelease }}
+          ReleaseType: ${{ fromJson(inputs.Settings).Module.ReleaseType }}
           APIKey: ${{ secrets.APIKey }}
           WhatIf: ${{ github.repository == 'PSModule/Process-PSModule' }}
           UsePRTitleAsReleaseName: ${{ fromJson(inputs.Settings).Publish.Module.UsePRTitleAsReleaseName }}

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -38,17 +38,26 @@ jobs:
           persist-credentials: false
 
       - name: Publish module
+        if: fromJson(inputs.Settings).Module.ReleaseType != 'None'
         uses: ./_wf/.github/actions/Publish-PSModule
         env:
           GH_TOKEN: ${{ github.token }}
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           ModulePath: outputs/module
-          ReleaseType: ${{ fromJson(inputs.Settings).Module.ReleaseType }}
           APIKey: ${{ secrets.APIKey }}
           WhatIf: ${{ github.repository == 'PSModule/Process-PSModule' }}
-          AutoCleanup: ${{ fromJson(inputs.Settings).Publish.Module.AutoCleanup }}
           UsePRTitleAsReleaseName: ${{ fromJson(inputs.Settings).Publish.Module.UsePRTitleAsReleaseName }}
           UsePRBodyAsReleaseNotes: ${{ fromJson(inputs.Settings).Publish.Module.UsePRBodyAsReleaseNotes }}
           UsePRTitleAsNotesHeading: ${{ fromJson(inputs.Settings).Publish.Module.UsePRTitleAsNotesHeading }}
+          WorkingDirectory: ${{ fromJson(inputs.Settings).WorkingDirectory }}
+
+      - name: Cleanup prereleases
+        if: fromJson(inputs.Settings).Module.ReleaseType != 'Prerelease'
+        uses: ./_wf/.github/actions/Cleanup-PSModulePrereleases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          WhatIf: ${{ github.repository == 'PSModule/Process-PSModule' }}
+          AutoCleanup: ${{ fromJson(inputs.Settings).Publish.Module.AutoCleanup }}
           WorkingDirectory: ${{ fromJson(inputs.Settings).WorkingDirectory }}

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           ModulePath: outputs/module
-          CreateRelease: ${{ fromJson(inputs.Settings).Module.CreateRelease }}
           ReleaseType: ${{ fromJson(inputs.Settings).Module.ReleaseType }}
           APIKey: ${{ secrets.APIKey }}
           WhatIf: ${{ github.repository == 'PSModule/Process-PSModule' }}

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           ModulePath: outputs/module
+          CreateRelease: ${{ fromJson(inputs.Settings).Module.CreateRelease }}
+          ReleaseType: ${{ fromJson(inputs.Settings).Module.ReleaseType }}
           APIKey: ${{ secrets.APIKey }}
           WhatIf: ${{ github.repository == 'PSModule/Process-PSModule' }}
           AutoCleanup: ${{ fromJson(inputs.Settings).Publish.Module.AutoCleanup }}

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           ModulePath: outputs/module
-          CreateRelease: ${{ fromJson(inputs.Settings).Module.CreateRelease }}
           ReleaseType: ${{ fromJson(inputs.Settings).Module.ReleaseType }}
           APIKey: ${{ secrets.APIKey }}
           WhatIf: ${{ github.repository == 'PSModule/Process-PSModule' }}

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish module
-        if: fromJson(inputs.Settings).Module.ReleaseType != 'None'
+        if: fromJson(inputs.Settings).Publish.Module.Resolution.ReleaseType != 'None'
         uses: ./_wf/.github/actions/Publish-PSModule
         env:
           GH_TOKEN: ${{ github.token }}
@@ -53,7 +53,7 @@ jobs:
           WorkingDirectory: ${{ fromJson(inputs.Settings).WorkingDirectory }}
 
       - name: Cleanup prereleases
-        if: fromJson(inputs.Settings).Module.ReleaseType != 'Prerelease'
+        if: fromJson(inputs.Settings).Publish.Module.Resolution.ReleaseType != 'Prerelease'
         uses: ./_wf/.github/actions/Cleanup-PSModulePrereleases
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           Name: ${{ fromJson(inputs.Settings).Name }}
           ModulePath: outputs/module
-          ReleaseType: ${{ fromJson(inputs.Settings).Module.ReleaseType }}
           APIKey: ${{ secrets.APIKey }}
           WhatIf: ${{ github.repository == 'PSModule/Process-PSModule' }}
           UsePRTitleAsReleaseName: ${{ fromJson(inputs.Settings).Publish.Module.UsePRTitleAsReleaseName }}


### PR DESCRIPTION
Prerelease cleanup now runs as an independent workflow action, so publish logic and cleanup logic can execute in the right scenarios without being coupled to module artifact download.

## Changed: Publish and cleanup are now separate actions
`Publish-PSModule` now only performs artifact download and publish/release work, while cleanup moved into a dedicated `Cleanup-PSModulePrereleases` action.

## Fixed: No-build cleanup paths no longer depend on publish action internals
`Publish-Module.yml` now runs publish only when `ReleaseType != 'None'`, and runs cleanup independently when `ReleaseType != 'Prerelease'` with existing AutoCleanup and WhatIf controls.

## Technical Details
- Removed cleanup inputs and cleanup step from `.github/actions/Publish-PSModule/action.yml`.
- Added `.github/actions/Cleanup-PSModulePrereleases/` with its own composite action and cleanup script.
- Updated `.github/workflows/Publish-Module.yml` to call the two actions as separate, scenario-gated steps.
- Preserved release-tag exclusion by passing `PSMODULE_PUBLISH_PSMODULE_CONTEXT_ReleaseTag` into the cleanup action when publish ran earlier in the job.
- Implementation plan progress: completed the decoupling requested in issue #376 by separating cleanup from publish artifact flow.

<details>
<summary>Related issues</summary>

- Fixes PSModule/Process-PSModule#376

</details>