### PR TITLE
⚙️ [Maintenance]: Authored Functions landing pages stay published

### DIFF
--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -2,7 +2,9 @@ name: Linter
 
 run-name: "Linter - [${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}] by @${{ github.actor }}"
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,6 +32,7 @@ jobs:
           FILTER_REGEX_EXCLUDE: 'tests/src(TestRepo|WithManifestTestRepo)/src/classes/public/.*\.ps1$'
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_GITHUB_ACTIONS: false
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON_PRETTIER: false
           VALIDATE_MARKDOWN_PRETTIER: false

--- a/.github/workflows/Workflow-Test-Default.yml
+++ b/.github/workflows/Workflow-Test-Default.yml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download docs artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: docs
           path: tests/srcTestRepo/outputs/docs
@@ -71,18 +71,22 @@ jobs:
         run: |
           $path = 'tests/srcTestRepo/outputs/docs/index.md'
           if (-not (Test-Path -Path $path)) {
-              throw 'Expected root Functions index at tests/srcTestRepo/outputs/docs/index.md.'
+              throw 'Expected root Functions index at ' +
+                  'tests/srcTestRepo/outputs/docs/index.md.'
           }
 
           $content = Get-Content -Path $path -Raw
           $expectedSnippets = @(
               '# Functions'
-              'This landing page is authored from the root of `src/functions/public`.'
-              'Use it to introduce the module''s function surface before readers drill into each group.'
+              'This landing page is authored from the root of ' +
+              '`src/functions/public`.'
+              'Use it to introduce the module''s function surface ' +
+              'before readers drill into each group.'
           )
 
           foreach ($snippet in $expectedSnippets) {
-              if ($content -notlike "*$snippet*") {
-                  throw "Expected snippet not found in generated root Functions index: $snippet"
+              if (-not $content.Contains($snippet)) {
+                  throw 'Expected snippet not found in generated root ' +
+                      "Functions index: $snippet"
               }
           }

--- a/.github/workflows/Workflow-Test-Default.yml
+++ b/.github/workflows/Workflow-Test-Default.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/workflows/**'
+      - 'tests/srcTestRepo/**'
       - '!.github/workflows/Release.yml'
       - '!.github/workflows/Linter.yml'
   schedule:
@@ -46,3 +47,43 @@ jobs:
         ^README\.md$
         ^\.github/actions/
         ^\.github/workflows/(?!Release\.yml$|Linter\.yml$)
+
+  VerifyRootFunctionsIndexDefault:
+    name: Verify root Functions index [Default]
+    runs-on: ubuntu-latest
+    needs:
+      - WorkflowTestDefault
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Download docs artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docs
+          path: tests/srcTestRepo/outputs/docs
+
+      - name: Verify root Functions index is published
+        shell: pwsh
+        run: |
+          $path = 'tests/srcTestRepo/outputs/docs/index.md'
+          if (-not (Test-Path -Path $path)) {
+              throw 'Expected root Functions index at tests/srcTestRepo/outputs/docs/index.md.'
+          }
+
+          $content = Get-Content -Path $path -Raw
+          $expectedSnippets = @(
+              'ms.title: Functions'
+              '# Functions'
+              'This landing page is authored from the root of `src/functions/public`.'
+              'Use it to introduce the module''s function surface before readers drill into each group.'
+          )
+
+          foreach ($snippet in $expectedSnippets) {
+              if ($content -notlike "*$snippet*") {
+                  throw "Expected snippet not found in generated root Functions index: $snippet"
+              }
+          }

--- a/.github/workflows/Workflow-Test-Default.yml
+++ b/.github/workflows/Workflow-Test-Default.yml
@@ -76,7 +76,6 @@ jobs:
 
           $content = Get-Content -Path $path -Raw
           $expectedSnippets = @(
-              'ms.title: Functions'
               '# Functions'
               'This landing page is authored from the root of `src/functions/public`.'
               'Use it to introduce the module''s function surface before readers drill into each group.'

--- a/.github/workflows/Workflow-Test-WithManifest.yml
+++ b/.github/workflows/Workflow-Test-WithManifest.yml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download docs artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: docs
           path: tests/srcWithManifestTestRepo/outputs/docs
@@ -71,18 +71,22 @@ jobs:
         run: |
           $path = 'tests/srcWithManifestTestRepo/outputs/docs/index.md'
           if (-not (Test-Path -Path $path)) {
-              throw 'Expected root Functions index at tests/srcWithManifestTestRepo/outputs/docs/index.md.'
+              throw 'Expected root Functions index at ' +
+                  'tests/srcWithManifestTestRepo/outputs/docs/index.md.'
           }
 
           $content = Get-Content -Path $path -Raw
           $expectedSnippets = @(
               '# Functions'
-              'This landing page is authored from the root of `src/functions/public`.'
-              'Use it to introduce the module''s function surface before readers drill into each group.'
+              'This landing page is authored from the root of ' +
+              '`src/functions/public`.'
+              'Use it to introduce the module''s function surface ' +
+              'before readers drill into each group.'
           )
 
           foreach ($snippet in $expectedSnippets) {
-              if ($content -notlike "*$snippet*") {
-                  throw "Expected snippet not found in generated root Functions index: $snippet"
+              if (-not $content.Contains($snippet)) {
+                  throw 'Expected snippet not found in generated root ' +
+                      "Functions index: $snippet"
               }
           }

--- a/.github/workflows/Workflow-Test-WithManifest.yml
+++ b/.github/workflows/Workflow-Test-WithManifest.yml
@@ -76,7 +76,6 @@ jobs:
 
           $content = Get-Content -Path $path -Raw
           $expectedSnippets = @(
-              'ms.title: Functions'
               '# Functions'
               'This landing page is authored from the root of `src/functions/public`.'
               'Use it to introduce the module''s function surface before readers drill into each group.'

--- a/.github/workflows/Workflow-Test-WithManifest.yml
+++ b/.github/workflows/Workflow-Test-WithManifest.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/workflows/**'
+      - 'tests/srcWithManifestTestRepo/**'
       - '!.github/workflows/Release.yml'
       - '!.github/workflows/Linter.yml'
   schedule:
@@ -46,3 +47,43 @@ jobs:
         ^README\.md$
         ^\.github/actions/
         ^\.github/workflows/(?!Release\.yml$|Linter\.yml$)
+
+  VerifyRootFunctionsIndexWithManifest:
+    name: Verify root Functions index [WithManifest]
+    runs-on: ubuntu-latest
+    needs:
+      - WorkflowTestWithManifest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Download docs artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docs
+          path: tests/srcWithManifestTestRepo/outputs/docs
+
+      - name: Verify root Functions index is published
+        shell: pwsh
+        run: |
+          $path = 'tests/srcWithManifestTestRepo/outputs/docs/index.md'
+          if (-not (Test-Path -Path $path)) {
+              throw 'Expected root Functions index at tests/srcWithManifestTestRepo/outputs/docs/index.md.'
+          }
+
+          $content = Get-Content -Path $path -Raw
+          $expectedSnippets = @(
+              'ms.title: Functions'
+              '# Functions'
+              'This landing page is authored from the root of `src/functions/public`.'
+              'Use it to introduce the module''s function surface before readers drill into each group.'
+          )
+
+          foreach ($snippet in $expectedSnippets) {
+              if ($content -notlike "*$snippet*") {
+                  throw "Expected snippet not found in generated root Functions index: $snippet"
+              }
+          }

--- a/tests/srcTestRepo/src/functions/public/index.md
+++ b/tests/srcTestRepo/src/functions/public/index.md
@@ -1,0 +1,10 @@
+---
+title: Functions
+description: A fully authored landing page for the exported function surface.
+---
+
+# Functions
+
+This landing page is authored from the root of `src/functions/public`.
+
+Use it to introduce the module's function surface before readers drill into each group.

--- a/tests/srcTestRepo/src/functions/public/index.md
+++ b/tests/srcTestRepo/src/functions/public/index.md
@@ -1,5 +1,4 @@
 ---
-title: Functions
 description: A fully authored landing page for the exported function surface.
 ---
 

--- a/tests/srcWithManifestTestRepo/src/functions/public/index.md
+++ b/tests/srcWithManifestTestRepo/src/functions/public/index.md
@@ -1,0 +1,10 @@
+---
+title: Functions
+description: A fully authored landing page for the exported function surface.
+---
+
+# Functions
+
+This landing page is authored from the root of `src/functions/public`.
+
+Use it to introduce the module's function surface before readers drill into each group.

--- a/tests/srcWithManifestTestRepo/src/functions/public/index.md
+++ b/tests/srcWithManifestTestRepo/src/functions/public/index.md
@@ -1,5 +1,4 @@
 ---
-title: Functions
 description: A fully authored landing page for the exported function surface.
 ---
 


### PR DESCRIPTION
Modules can carry an authored `src/functions/public/index.md` that becomes the top-level Functions landing page in the generated documentation, giving readers a stable introduction before they drill into grouped commands.

## Changed: Authored Functions landing pages stay published

An authored root Functions page is preserved in the generated documentation artifact as `outputs/docs/index.md`, so it is published as `Functions/index.md` without requiring module authors to change their existing documentation workflow.

---
<details>
<summary>Technical details</summary>

- Added authored root index fixtures to `tests/srcTestRepo` and `tests/srcWithManifestTestRepo`.
- Extended `Workflow-Test-Default.yml` and `Workflow-Test-WithManifest.yml` to run for fixture changes and verify the generated root index content.
- Reused the existing `Build-PSModuleDocumentation.ps1` move logic; no generator change was required.
- Implementation plan progress: completed the first slice for fully authored root indexes. Placeholder-driven generated submodule tables remain follow-up work.

| Changed surface | Standards checked | Framework docs checked | Result |
| --- | --- | --- | --- |
| `tests/**` (PowerShell fixtures) | Test fixture conventions | Process-PSModule test workflow | Aligned |
| `.github/workflows/**` (GitHub Actions) | Workflow conventions | Process-PSModule documentation pipeline | Aligned |

- Issue convergence sweep: reviewed PSModule/Process-PSModule#379; this PR delivers the authored-root-index slice only, while placeholder and generated-table behavior remains open.

</details>

<details>
<summary>Relevant issues (or links)</summary>

- PSModule/Process-PSModule#379

</details>