### PR TITLE
⚙️ [Maintenance]: Module source tests align with latest PowerShell LTS

### DIFF
--- a/.github/actions/Test-PSModule/src/tests/SourceCode/PSModule/PSModule.Tests.ps1
+++ b/.github/actions/Test-PSModule/src/tests/SourceCode/PSModule/PSModule.Tests.ps1
@@ -163,24 +163,6 @@ Describe 'PSModule - SourceCode tests' {
             $issues -join [Environment]::NewLine |
                 Should -BeNullOrEmpty -Because "the script should use '`$null = ...' instead of '... | Out-Null'"
         }
-        It 'Should not use ternary operations for compatibility reasons (ID: NoTernary)' -Skip {
-            $issues = @('')
-            $scriptFiles | ForEach-Object {
-                $filePath = $_.FullName
-                $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:NoTernary:(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0) {
-                    $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                    Write-Host "::warning title=Skipping NoTernary test:: - $relativePath - $skipReason"
-                } else {
-                    Select-String -Path $filePath -Pattern '(?<!\|)\s+\?\s' -AllMatches | ForEach-Object {
-                        $issues += " - $relativePath`:L$($_.LineNumber) - $($_.Line)"
-                    }
-                }
-            }
-            $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'the script should not use ternary operations for compatibility with PS 5.1 and below'
-        }
         It 'all powershell keywords are lowercase (ID: LowercaseKeywords)' {
             $issues = @('')
             $scriptFiles | ForEach-Object {


### PR DESCRIPTION
Module source validation no longer carries the obsolete PowerShell 5.1 ternary compatibility rule. PSModule modules targeting the latest PowerShell LTS can use ternary operators without an outdated framework restriction.

## Changed: Ternary operators are allowed

The source-code test suite no longer checks for or supports bypassing the retired `NoTernary` rule. No other source-code rules change.

## Technical Details

- Removed the `NoTernary` Pester test and its `#SkipTest:NoTernary:` handling from `.github/actions/Test-PSModule/src/tests/SourceCode/PSModule/PSModule.Tests.ps1`.
- This maintenance change was explicitly authorized by direct user request without a linked issue.