### PR TITLE
🪲 [Fix]: Pipeline no longer fails on a module repository with no releases

### DIFF
--- a/.github/actions/Resolve-PSModuleVersion/src/Resolve-PSModuleVersion.Helpers.psm1
+++ b/.github/actions/Resolve-PSModuleVersion/src/Resolve-PSModuleVersion.Helpers.psm1
@@ -298,7 +298,9 @@ function Get-GitHubRelease {
             Write-Error 'Failed to list releases for the repo.'
             exit $LASTEXITCODE
         }
-        $releases = $releasesJson | ConvertFrom-Json
+        # A repository that has never released returns '[]', which deserializes to nothing. Wrap the
+        # result so callers always receive an array, even for a module being bootstrapped.
+        $releases = @($releasesJson | ConvertFrom-Json)
 
         Write-Host '-------------------------------------------------'
         Write-Host ($releases | Select-Object -Property name, isPrerelease, isLatest, publishedAt |
@@ -327,6 +329,7 @@ function Get-LatestGitHubVersion {
     param(
         # The GitHub releases array to search.
         [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
         [array] $Releases
     )
 
@@ -474,6 +477,7 @@ function Get-NextPrereleaseNumber {
 
         # The GitHub releases list.
         [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
         [array] $Releases
     )
 
@@ -551,6 +555,7 @@ function Get-NextModuleVersion {
 
         # The GitHub releases list, used for incremental prerelease calculation.
         [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
         [array] $Releases
     )
 

--- a/.github/actions/Resolve-PSModuleVersion/src/main.ps1
+++ b/.github/actions/Resolve-PSModuleVersion/src/main.ps1
@@ -28,7 +28,7 @@ $decision = if ($null -eq $pullRequest) {
     Resolve-ReleaseDecision -Configuration $config -PullRequest $pullRequest
 }
 
-$releases = Get-GitHubRelease
+$releases = @(Get-GitHubRelease)
 $ghVersion = Get-LatestGitHubVersion -Releases $releases
 $psGalleryVersion = Get-LatestPSGalleryVersion -ModuleName $actionInput.Name
 $latestVersion = Get-LatestPublishedVersion -GitHubVersion $ghVersion -PSGalleryVersion $psGalleryVersion


### PR DESCRIPTION
The first pull request in a brand-new module repository now runs the full pipeline. Until now it failed in the **Plan** job with `Cannot bind argument to parameter 'Releases' because it is null`, and every other job was skipped, so a maintainer bootstrapping a module could not get a green pipeline on the pull request meant to produce the first release.

## Fixed: The pipeline no longer fails on a repository with no releases

A repository that has never published a release is now treated as the normal starting state of a module. Version resolution floors at `0.0.0`, the pull request release label bumps from there, and build, test, lint, and publish run as they do for any other pull request.

Nothing changes for repositories that already have releases.

The workaround of publishing a placeholder `v0.0.0` release before opening the first pull request is no longer needed.

## Technical Details

`Get-GitHubRelease` runs `gh release list --json ...`, which answers `[]` for a repository with no releases. `'[]' | ConvertFrom-Json` emits nothing, so the value collapsed to `$null` on the way out of the function, and `Get-LatestGitHubVersion`, `Get-NextModuleVersion`, and `Get-NextPrereleaseNumber` all reject `$null` on their mandatory `[array] $Releases` parameter.

- `Get-GitHubRelease` wraps the deserialized result in `@(...)`, and the call site in `main.ps1` wraps the returned value the same way so the empty array survives the assignment.
- `[AllowEmptyCollection()]` added to the `Releases` parameter of `Get-LatestGitHubVersion`, `Get-NextModuleVersion`, and `Get-NextPrereleaseNumber`. A mandatory parameter rejects an empty collection as well as `$null`, so both guards are needed. All three already handle an empty list correctly: the version lookup warns and falls back to `0.0.0`, and the prerelease number lookup simply finds no matching tags.
- Implementation plan progress: all four core tasks in the linked issue are complete.

<details>
<summary>Related issues</summary>

- Fixes PSModule/Process-PSModule#434

</details>
