### PR TITLE
⚙️ [Maintenance]: Process workflow fleets can be inspected and migrated safely

### DIFF
--- a/.github/extensions/process-workflow-fleet/README.md
+++ b/.github/extensions/process-workflow-fleet/README.md
@@ -1,0 +1,102 @@
+# Process workflow fleet canvas
+
+This project-scoped Copilot canvas lets maintainers refresh the authenticated
+Process-PSModule caller inventory, inspect each repository against the v8 caller
+contract, and send a confirmed migration request to the active agent. The
+loopback server never edits another repository or opens a pull request.
+
+## Structure
+
+| File | Responsibility |
+| --- | --- |
+| `extension.mjs` | Declares the canvas, strict open/action schemas, lifecycle, and SDK wiring. |
+| `fleet-service.mjs` | Resolves the repository, stores workspace-scoped state, runs inventory refreshes, serves loopback HTTP, and calls `session.send()`. |
+| `fleet-model.mjs` | Normalizes inventory records, encodes the v8 target, computes deltas, and builds structured migration prompts. |
+| `renderer.mjs` | Returns the dependency-free dashboard HTML, CSS, and browser interactions. |
+| `fleet-model.test.mjs` | Tests normalization, comparison, fail-closed behavior, and prompt generation with built-in Node modules. |
+
+`extension.mjs` must remain an ES module with that exact name. Copilot resolves
+`@github/copilot-sdk` for the extension process, so this directory does not need
+a `package.json` or `node_modules`.
+
+## Load and open
+
+Copilot discovers immediate children of `.github/extensions/`. After changing
+the extension, reload project extensions and confirm
+`project:process-workflow-fleet` is running:
+
+```text
+extensions_reload({})
+extensions_manage({ operation: "list" })
+extensions_manage({ operation: "inspect", name: "process-workflow-fleet" })
+```
+
+Inspect the declaration, then open a stable panel instance:
+
+```text
+list_canvas_capabilities({ canvasId: "process-workflow-fleet" })
+open_canvas({
+  canvasId: "process-workflow-fleet",
+  instanceId: "process-workflow-fleet-main",
+  input: { organization: "PSModule" }
+})
+```
+
+Reopening the same `instanceId` focuses the panel. Durable inventory and
+selection state is keyed by the repository workspace under the Copilot session
+`files/process-workflow-fleet/` artifact directory, not by the panel ID.
+Refreshed evidence is disposable user-specific state and is never committed
+automatically.
+
+## Use and test
+
+The dashboard refresh button runs
+`.github/scripts/Get-ProcessPSModuleWorkflowInventory.ps1` in authenticated
+GitHub mode with target `v8`. A failed refresh clears prior success state and
+shows the command context and sanitized diagnostic.
+
+Agent-facing actions are:
+
+- `refresh_inventory`
+- `get_summary`
+- `get_repository`
+- `set_selection`
+- `request_migration`
+
+`request_migration` returns a preview by default. It calls `session.send()` only
+when `dryRun` is `false`, `confirmed` is `true`, the selection is nonempty, and
+the current inventory is complete.
+
+Run deterministic helper tests with:
+
+```powershell
+node --test .github/extensions/process-workflow-fleet/fleet-model.test.mjs
+```
+
+## Debug
+
+Start with `extensions_manage({ operation: "inspect", name:
+"process-workflow-fleet" })`. The reported log captures provider startup and
+runtime failures; do not add `console.log`, because standard output carries the
+JSON-RPC protocol. Use `session.log()` for deliberate diagnostics.
+
+For lifecycle and schema checks, reload before testing and verify:
+
+1. discovery and capabilities;
+2. valid and invalid open input;
+3. each declared action and invalid action input;
+4. reserved `canvas.*` action rejection;
+5. loopback rendering and panel cleanup.
+
+## Extend safely
+
+Keep the SDK declaration in `extension.mjs`, domain logic in
+`fleet-model.mjs`, privileged boundaries in `fleet-service.mjs`, and rendering
+in `renderer.mjs`. Add a strict JSON schema for every new agent action and a
+deterministic test for every comparison or prompt change.
+
+Bind HTTP only to `127.0.0.1`, require the per-panel request token for writes,
+and close the server in `onClose`. HTTP handlers may prepare evidence or
+requests, but repository mutations must stay in normal Copilot sessions where
+the user can see tool calls and permission prompts. Never include credentials
+in state, HTML, diagnostics, or migration requests.

--- a/.github/extensions/process-workflow-fleet/README.md
+++ b/.github/extensions/process-workflow-fleet/README.md
@@ -50,7 +50,8 @@ automatically.
 
 ## Use and test
 
-The dashboard refresh button runs
+The dashboard automatically refreshes missing inventory and evidence older than
+15 minutes. Its refresh button provides an explicit retry. Both paths run
 `.github/scripts/Get-ProcessPSModuleWorkflowInventory.ps1` in authenticated
 GitHub mode with target `v8`. A failed refresh clears prior success state and
 shows the command context and sanitized diagnostic.

--- a/.github/extensions/process-workflow-fleet/extension.mjs
+++ b/.github/extensions/process-workflow-fleet/extension.mjs
@@ -1,0 +1,89 @@
+// Extension: process-workflow-fleet
+// Inspect Process-PSModule caller workflows and prepare safe v8 migrations.
+//
+// This single-file skeleton is a starting point. For more complex canvases
+// (multiple actions with non-trivial logic, shared state, a custom renderer,
+// etc.) prefer splitting things out: move each action handler into its own
+// function, extract `open`/`onClose` into helpers, and pull large units
+// (renderer assets, schema definitions, shared utilities) into sibling files
+// imported from this entry point. Keep extension.mjs focused on wiring.
+
+import { createServer } from "node:http";
+import { joinSession, createCanvas } from "@github/copilot-sdk/extension";
+
+// One local HTTP server per open canvas instance. Each instance gets its own
+// ephemeral port so multiple canvases (or multiple opens of the same canvas)
+// don't collide. Replace this with your real renderer — point a static-file
+// server, a Vite/Next dev server, or any framework you like at the same URL.
+const servers = new Map();
+
+function renderHtml(instanceId) {
+    return `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>process-workflow-fleet</title></head>
+  <body style="font-family: system-ui; padding: 1rem;">
+    <h1>process-workflow-fleet</h1>
+    <p>Hello from a local canvas server.</p>
+    <p>Instance: <code>${instanceId}</code></p>
+  </body>
+</html>`;
+}
+
+async function startServer(instanceId) {
+    const server = createServer((req, res) => {
+        res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.end(renderHtml(instanceId));
+    });
+    // Port 0 = let the OS pick a free ephemeral port. Bind to loopback only.
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    return { server, url: `http://127.0.0.1:${port}/` };
+}
+
+const session = await joinSession({
+    canvases: [
+        createCanvas({
+            id: "process-workflow-fleet",
+            displayName: "process-workflow-fleet",
+            description: "Example canvas - replace with your implementation",
+            // Optional JSON Schema describing the input passed to open():
+            // inputSchema: { type: "object", properties: {} },
+            actions: [
+                {
+                    name: "example_action",
+                    description: "Example agent-callable action on this canvas",
+                    // Optional JSON Schema for the action input:
+                    // inputSchema: { type: "object", properties: {} },
+                    handler: async (ctx) => {
+                        return { ok: true, instanceId: ctx.instanceId };
+                    },
+                },
+            ],
+            // Called when the agent or host opens the canvas. We boot a local
+            // HTTP server on an ephemeral port and hand its URL back to the
+            // host so it can render the canvas. Re-opens with the same
+            // instanceId reuse the existing server.
+            open: async (ctx) => {
+                let entry = servers.get(ctx.instanceId);
+                if (!entry) {
+                    entry = await startServer(ctx.instanceId);
+                    servers.set(ctx.instanceId, entry);
+                }
+                return {
+                    title: "process-workflow-fleet",
+                    url: entry.url,
+                };
+            },
+            // Tear the per-instance server down when the canvas is closed so
+            // ports are not leaked across the lifetime of the extension.
+            onClose: async (ctx) => {
+                const entry = servers.get(ctx.instanceId);
+                if (entry) {
+                    servers.delete(ctx.instanceId);
+                    await new Promise((resolve) => entry.server.close(() => resolve()));
+                }
+            },
+        }),
+    ],
+});

--- a/.github/extensions/process-workflow-fleet/extension.mjs
+++ b/.github/extensions/process-workflow-fleet/extension.mjs
@@ -157,16 +157,12 @@ const canvas = createCanvas({
         },
     ],
     open: async (ctx) => {
-        const state = await fleet.ensureState({
+        const entry = await fleet.openPanel(ctx.instanceId, {
             organization: ctx.input?.organization,
         });
-        const entry = await fleet.openPanel(ctx.instanceId);
         return {
             title: "Process workflow fleet",
-            status:
-                state.inventoryStatus === "ready"
-                    ? `${state.records.length} workflows`
-                    : "Refresh required",
+            status: "Inventory updates automatically",
             url: entry.url,
         };
     },

--- a/.github/extensions/process-workflow-fleet/extension.mjs
+++ b/.github/extensions/process-workflow-fleet/extension.mjs
@@ -1,89 +1,182 @@
-// Extension: process-workflow-fleet
-// Inspect Process-PSModule caller workflows and prepare safe v8 migrations.
-//
-// This single-file skeleton is a starting point. For more complex canvases
-// (multiple actions with non-trivial logic, shared state, a custom renderer,
-// etc.) prefer splitting things out: move each action handler into its own
-// function, extract `open`/`onClose` into helpers, and pull large units
-// (renderer assets, schema definitions, shared utilities) into sibling files
-// imported from this entry point. Keep extension.mjs focused on wiring.
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { createServer } from "node:http";
-import { joinSession, createCanvas } from "@github/copilot-sdk/extension";
+import {
+    CanvasError,
+    createCanvas,
+    joinSession,
+} from "@github/copilot-sdk/extension";
 
-// One local HTTP server per open canvas instance. Each instance gets its own
-// ephemeral port so multiple canvases (or multiple opens of the same canvas)
-// don't collide. Replace this with your real renderer — point a static-file
-// server, a Vite/Next dev server, or any framework you like at the same URL.
-const servers = new Map();
+import {
+    createFleetService,
+    resolveRepositoryRoot,
+} from "./fleet-service.mjs";
 
-function renderHtml(instanceId) {
-    return `<!doctype html>
-<html>
-  <head><meta charset="utf-8" /><title>process-workflow-fleet</title></head>
-  <body style="font-family: system-ui; padding: 1rem;">
-    <h1>process-workflow-fleet</h1>
-    <p>Hello from a local canvas server.</p>
-    <p>Instance: <code>${instanceId}</code></p>
-  </body>
-</html>`;
-}
+const moduleDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolveRepositoryRoot({
+    currentWorkingDirectory: process.cwd(),
+    moduleDirectory,
+});
 
-async function startServer(instanceId) {
-    const server = createServer((req, res) => {
-        res.setHeader("Content-Type", "text/html; charset=utf-8");
-        res.end(renderHtml(instanceId));
-    });
-    // Port 0 = let the OS pick a free ephemeral port. Bind to loopback only.
-    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-    const address = server.address();
-    const port = typeof address === "object" && address ? address.port : 0;
-    return { server, url: `http://127.0.0.1:${port}/` };
-}
+let session;
+const fleet = createFleetService({
+    getSession: () => session,
+    repositoryRoot,
+});
 
-const session = await joinSession({
-    canvases: [
-        createCanvas({
-            id: "process-workflow-fleet",
-            displayName: "process-workflow-fleet",
-            description: "Example canvas - replace with your implementation",
-            // Optional JSON Schema describing the input passed to open():
-            // inputSchema: { type: "object", properties: {} },
-            actions: [
-                {
-                    name: "example_action",
-                    description: "Example agent-callable action on this canvas",
-                    // Optional JSON Schema for the action input:
-                    // inputSchema: { type: "object", properties: {} },
-                    handler: async (ctx) => {
-                        return { ok: true, instanceId: ctx.instanceId };
+const canvas = createCanvas({
+    id: "process-workflow-fleet",
+    displayName: "Process workflow fleet",
+    description:
+        "Inspect Process-PSModule caller workflows, compare them with the v8 contract, and request repository-scoped migrations.",
+    inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+            organization: {
+                type: "string",
+                minLength: 1,
+                maxLength: 100,
+                pattern: "^[A-Za-z0-9][A-Za-z0-9-]*$",
+            },
+        },
+    },
+    actions: [
+        {
+            name: "refresh_inventory",
+            description:
+                "Refresh the authenticated GitHub inventory and replace prior canvas data fail-closed.",
+            inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                    organization: {
+                        type: "string",
+                        minLength: 1,
+                        maxLength: 100,
+                        pattern: "^[A-Za-z0-9][A-Za-z0-9-]*$",
+                    },
+                    repositories: {
+                        type: "array",
+                        uniqueItems: true,
+                        maxItems: 500,
+                        items: {
+                            type: "string",
+                            minLength: 1,
+                            maxLength: 200,
+                            pattern:
+                                "^[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?$",
+                        },
+                    },
+                    includeArchived: {
+                        type: "boolean",
                     },
                 },
-            ],
-            // Called when the agent or host opens the canvas. We boot a local
-            // HTTP server on an ephemeral port and hand its URL back to the
-            // host so it can render the canvas. Re-opens with the same
-            // instanceId reuse the existing server.
-            open: async (ctx) => {
-                let entry = servers.get(ctx.instanceId);
-                if (!entry) {
-                    entry = await startServer(ctx.instanceId);
-                    servers.set(ctx.instanceId, entry);
-                }
-                return {
-                    title: "process-workflow-fleet",
-                    url: entry.url,
-                };
             },
-            // Tear the per-instance server down when the canvas is closed so
-            // ports are not leaked across the lifetime of the extension.
-            onClose: async (ctx) => {
-                const entry = servers.get(ctx.instanceId);
-                if (entry) {
-                    servers.delete(ctx.instanceId);
-                    await new Promise((resolve) => entry.server.close(() => resolve()));
-                }
+            handler: async (ctx) => fleet.refreshInventory(ctx.input ?? {}),
+        },
+        {
+            name: "get_summary",
+            description:
+                "Return refresh health and v8 compliance counts for the current workspace inventory.",
+            inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                properties: {},
             },
-        }),
+            handler: async () => fleet.getSummary(),
+        },
+        {
+            name: "get_repository",
+            description:
+                "Return normalized workflow evidence and the migration delta for one repository.",
+            inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                required: ["repository"],
+                properties: {
+                    repository: {
+                        type: "string",
+                        minLength: 1,
+                        maxLength: 200,
+                    },
+                },
+            },
+            handler: async (ctx) => fleet.getRepository(ctx.input.repository),
+        },
+        {
+            name: "set_selection",
+            description:
+                "Persist the selected repository identities for this session workspace.",
+            inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                required: ["repositories"],
+                properties: {
+                    repositories: {
+                        type: "array",
+                        uniqueItems: true,
+                        maxItems: 500,
+                        items: {
+                            type: "string",
+                            minLength: 1,
+                            maxLength: 200,
+                        },
+                    },
+                },
+            },
+            handler: async (ctx) => fleet.setSelection(ctx.input.repositories),
+        },
+        {
+            name: "request_migration",
+            description:
+                "Preview or confirm an agent-orchestrated migration request for selected repositories; never mutates repositories directly.",
+            inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                    repositories: {
+                        type: "array",
+                        uniqueItems: true,
+                        maxItems: 500,
+                        items: {
+                            type: "string",
+                            minLength: 1,
+                            maxLength: 200,
+                        },
+                    },
+                    dryRun: {
+                        type: "boolean",
+                    },
+                    confirmed: {
+                        type: "boolean",
+                    },
+                },
+            },
+            handler: async (ctx) => fleet.requestMigration(ctx.input ?? {}),
+        },
     ],
+    open: async (ctx) => {
+        const state = await fleet.ensureState({
+            organization: ctx.input?.organization,
+        });
+        const entry = await fleet.openPanel(ctx.instanceId);
+        return {
+            title: "Process workflow fleet",
+            status:
+                state.inventoryStatus === "ready"
+                    ? `${state.records.length} workflows`
+                    : "Refresh required",
+            url: entry.url,
+        };
+    },
+    onClose: async (ctx) => {
+        await fleet.closePanel(ctx.instanceId);
+    },
 });
+
+session = await joinSession({
+    canvases: [canvas],
+});
+
+fleet.setCanvasErrorFactory((code, message) => new CanvasError(code, message));

--- a/.github/extensions/process-workflow-fleet/fleet-model.mjs
+++ b/.github/extensions/process-workflow-fleet/fleet-model.mjs
@@ -1,0 +1,644 @@
+const EXPECTED_WORKFLOW_PATH = ".github/workflows/Process-PSModule.yml";
+const EXPECTED_WORKFLOW_NAME = "Process-PSModule";
+const EXPECTED_JOB_NAME = "Process-PSModule";
+const EXPECTED_USES =
+    "PSModule/Process-PSModule/.github/workflows/workflow.yml@v8";
+const EXPECTED_CONCURRENCY_GROUP =
+    "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}";
+const EXPECTED_CANCEL_IN_PROGRESS =
+    "${{ github.event_name == 'pull_request' }}";
+
+const REQUIRED_EVENTS = [
+    "pull_request",
+    "push",
+    "schedule",
+    "workflow_dispatch",
+];
+const REQUIRED_PULL_REQUEST_TYPES = [
+    "closed",
+    "labeled",
+    "opened",
+    "reopened",
+    "synchronize",
+    "unlabeled",
+];
+const REQUIRED_JOB_PERMISSIONS = {
+    contents: "read",
+    pages: "write",
+    "id-token": "write",
+};
+const REQUIRED_SECRETS = {
+    PSGALLERY_API_KEY: "${{ secrets.PSGALLERY_API_KEY }}",
+    GitHubAppClientId: "${{ secrets.SHELLY_CLIENT_ID }}",
+    GitHubAppPrivateKey: "${{ secrets.SHELLY_PRIVATE_KEY }}",
+};
+const OPTIONAL_INPUTS = new Set([
+    "ImportantFilePatterns",
+    "Prerelease",
+    "SettingsPath",
+    "Verbose",
+    "Version",
+    "WorkingDirectory",
+]);
+const OPTIONAL_SECRETS = new Set(["TestData"]);
+
+const REQUIRED_RECORD_FIELDS = [
+    "WorkflowName",
+    "Events",
+    "Schedules",
+    "PushBranches",
+    "PushBranchesIgnore",
+    "PushPaths",
+    "PushPathsIgnore",
+    "PullRequestBranches",
+    "PullRequestTypes",
+    "PullRequestPaths",
+    "PullRequestPathsIgnore",
+    "ConcurrencyGroup",
+    "CancelInProgress",
+    "Permissions",
+    "ProcessJobs",
+    "AdditionalJobs",
+];
+const REQUIRED_JOB_FIELDS = [
+    "Name",
+    "Uses",
+    "Reference",
+    "Inputs",
+    "SecretMode",
+    "SecretMappings",
+    "Permissions",
+    "Condition",
+];
+
+export const TARGET_CONTRACT = Object.freeze({
+    identity: {
+        workflowPath: EXPECTED_WORKFLOW_PATH,
+        workflowName: EXPECTED_WORKFLOW_NAME,
+        jobName: EXPECTED_JOB_NAME,
+    },
+    triggers: {
+        events: REQUIRED_EVENTS,
+        scheduleRequired: true,
+        pushBranches: ["main"],
+        pullRequestBranches: ["main"],
+        pullRequestTypes: REQUIRED_PULL_REQUEST_TYPES,
+        pathFiltersAllowed: false,
+    },
+    concurrency: {
+        group: EXPECTED_CONCURRENCY_GROUP,
+        cancelInProgress: EXPECTED_CANCEL_IN_PROGRESS,
+    },
+    permissions: {
+        workflow: {},
+        job: REQUIRED_JOB_PERMISSIONS,
+    },
+    caller: {
+        condition: null,
+        uses: EXPECTED_USES,
+        secrets: REQUIRED_SECRETS,
+        optionalSecrets: [...OPTIONAL_SECRETS],
+        optionalInputs: [...OPTIONAL_INPUTS].sort(),
+        debugTrueAllowed: false,
+    },
+    additionalJobs: {
+        allowed: true,
+        boundaryReviewRequired: true,
+    },
+});
+
+function hasOwn(value, property) {
+    return (
+        value !== null &&
+        typeof value === "object" &&
+        Object.prototype.hasOwnProperty.call(value, property)
+    );
+}
+
+function toArray(value) {
+    if (value === null || value === undefined) {
+        return [];
+    }
+    return Array.isArray(value) ? value : [value];
+}
+
+function toObject(value) {
+    if (
+        value === null ||
+        value === undefined ||
+        Array.isArray(value) ||
+        typeof value !== "object"
+    ) {
+        return {};
+    }
+    return { ...value };
+}
+
+function normalizedScalar(value) {
+    if (value === null || value === undefined) {
+        return null;
+    }
+    return typeof value === "string" ? value.trim() : value;
+}
+
+function normalizeJob(job, index) {
+    const source = toObject(job);
+    return {
+        sourceIndex: index,
+        sourceFields: Object.keys(source),
+        name: normalizedScalar(source.Name),
+        uses: normalizedScalar(source.Uses),
+        reference: normalizedScalar(source.Reference),
+        inputs: toObject(source.Inputs),
+        secretMode: normalizedScalar(source.SecretMode),
+        secretMappings: toObject(source.SecretMappings),
+        permissions: source.Permissions,
+        environment: source.Environment ?? null,
+        condition: normalizedScalar(source.Condition),
+    };
+}
+
+function normalizeRecord(record, index) {
+    const source = toObject(record);
+    const status = source.Status === "ParseError" ? "parse-error" : "parsed";
+    return {
+        sourceIndex: index,
+        sourceFields: Object.keys(source),
+        repository: normalizedScalar(source.Repository) ?? `unknown-${index + 1}`,
+        defaultBranch: normalizedScalar(source.DefaultBranch),
+        archived: source.Archived === true,
+        repositoryUrl: normalizedScalar(source.RepositoryUrl),
+        workflowPath: normalizedScalar(source.WorkflowPath),
+        workflowUrl: normalizedScalar(source.WorkflowUrl),
+        status,
+        error: normalizedScalar(source.Error),
+        workflowName: normalizedScalar(source.WorkflowName),
+        runName: normalizedScalar(source.RunName),
+        events: toArray(source.Events).map(String),
+        schedules: toArray(source.Schedules).map(String),
+        pushBranches: toArray(source.PushBranches).map(String),
+        pushBranchesIgnore: toArray(source.PushBranchesIgnore).map(String),
+        pushPaths: toArray(source.PushPaths).map(String),
+        pushPathsIgnore: toArray(source.PushPathsIgnore).map(String),
+        pullRequestBranches: toArray(source.PullRequestBranches).map(String),
+        pullRequestTypes: toArray(source.PullRequestTypes).map(String),
+        pullRequestPaths: toArray(source.PullRequestPaths).map(String),
+        pullRequestPathsIgnore: toArray(source.PullRequestPathsIgnore).map(String),
+        concurrencyGroup: normalizedScalar(source.ConcurrencyGroup),
+        cancelInProgress: normalizedScalar(source.CancelInProgress),
+        permissions: source.Permissions,
+        processJobs: toArray(source.ProcessJobs).map(normalizeJob),
+        additionalJobs: toArray(source.AdditionalJobs).map(String),
+        versionComments: toArray(source.VersionComments).map((entry) => ({
+            reference: normalizedScalar(entry?.Reference),
+            version: normalizedScalar(entry?.Version),
+        })),
+    };
+}
+
+export function normalizeInventory(value) {
+    const records = Array.isArray(value) ? value : value ? [value] : [];
+    return records.map(normalizeRecord);
+}
+
+function stableJson(value) {
+    if (Array.isArray(value)) {
+        return JSON.stringify([...value].map(String).sort());
+    }
+    if (value !== null && typeof value === "object") {
+        return JSON.stringify(
+            Object.fromEntries(
+                Object.entries(value)
+                    .sort(([left], [right]) => left.localeCompare(right))
+                    .map(([key, entry]) => [key, entry]),
+            ),
+        );
+    }
+    return JSON.stringify(value ?? null);
+}
+
+function equalArray(actual, expected) {
+    return stableJson(actual) === stableJson(expected);
+}
+
+function equalObject(actual, expected) {
+    return stableJson(toObject(actual)) === stableJson(expected);
+}
+
+function missingInventoryFields(record) {
+    const missing = REQUIRED_RECORD_FIELDS.filter(
+        (field) => !record.sourceFields.includes(field),
+    );
+    for (const job of record.processJobs) {
+        for (const field of REQUIRED_JOB_FIELDS) {
+            if (!job.sourceFields.includes(field)) {
+                missing.push(`ProcessJobs[${job.sourceIndex}].${field}`);
+            }
+        }
+    }
+    return missing;
+}
+
+function addDelta(deltas, field, current, target, matches, instruction) {
+    if (!matches) {
+        deltas.push({
+            field,
+            current,
+            target,
+            instruction,
+        });
+    }
+}
+
+function isEmptyCondition(value) {
+    return value === null || value === "";
+}
+
+function hasDebugTrue(inputs) {
+    return Object.entries(inputs).some(
+        ([key, value]) =>
+            key.toLowerCase() === "debug" &&
+            String(value).trim().toLowerCase() === "true",
+    );
+}
+
+function compareSecrets(job, deltas) {
+    addDelta(
+        deltas,
+        "job.secretMode",
+        job.secretMode,
+        "explicit",
+        job.secretMode === "explicit",
+        "Replace inherited or missing secrets with explicit mappings.",
+    );
+
+    for (const [name, target] of Object.entries(REQUIRED_SECRETS)) {
+        addDelta(
+            deltas,
+            `job.secrets.${name}`,
+            job.secretMappings[name] ?? null,
+            target,
+            job.secretMappings[name] === target,
+            `Map ${name} to the agreed repository or organization secret.`,
+        );
+    }
+
+    const unsupported = Object.keys(job.secretMappings).filter(
+        (name) => !hasOwn(REQUIRED_SECRETS, name) && !OPTIONAL_SECRETS.has(name),
+    );
+    addDelta(
+        deltas,
+        "job.secrets.unsupported",
+        unsupported,
+        [],
+        unsupported.length === 0,
+        "Remove unsupported mappings after checking whether they belong in TestData.",
+    );
+}
+
+function compareInputs(job, deltas, preservation) {
+    const inputNames = Object.keys(job.inputs);
+    if (hasOwn(job.inputs, "TestData")) {
+        deltas.push({
+            field: "job.inputs.TestData",
+            current: job.inputs.TestData,
+            target: "secret mapping named TestData",
+            instruction:
+                "Move test data to the optional TestData secret mapping without exposing values.",
+        });
+    }
+
+    addDelta(
+        deltas,
+        "job.inputs.Debug",
+        job.inputs.Debug ?? null,
+        "omitted or false",
+        !hasDebugTrue(job.inputs),
+        "Remove Debug: true so the reusable workflow default remains false.",
+    );
+
+    const unsupported = inputNames.filter(
+        (name) =>
+            name !== "Debug" &&
+            name !== "TestData" &&
+            !OPTIONAL_INPUTS.has(name),
+    );
+    addDelta(
+        deltas,
+        "job.inputs.unsupported",
+        unsupported,
+        [],
+        unsupported.length === 0,
+        "Inspect unsupported inputs against the current reusable-workflow interface.",
+    );
+
+    for (const name of inputNames.filter((entry) => OPTIONAL_INPUTS.has(entry))) {
+        preservation.push({
+            field: `job.inputs.${name}`,
+            value: job.inputs[name],
+            instruction: `Preserve ${name} when it remains valid for this repository.`,
+        });
+    }
+    if (hasOwn(job.secretMappings, "TestData")) {
+        preservation.push({
+            field: "job.secrets.TestData",
+            value: job.secretMappings.TestData,
+            instruction:
+                "Preserve the TestData JSON mapping after verifying referenced secrets and variables.",
+        });
+    }
+}
+
+export function compareRepository(record) {
+    if (record.status === "parse-error") {
+        return {
+            repository: record.repository,
+            workflowPath: record.workflowPath,
+            status: "parse-error",
+            compliant: false,
+            complete: false,
+            requestReady: false,
+            missingFields: [],
+            deltas: [
+                {
+                    field: "inventory.parse",
+                    current: record.error,
+                    target: "a parsed workflow",
+                    instruction:
+                        "Fix or inspect the YAML parse error before planning migration.",
+                },
+            ],
+            preservation: [],
+            reviewWarnings: [],
+        };
+    }
+
+    const missingFields = missingInventoryFields(record);
+    const deltas = [];
+    const preservation = [];
+    const reviewWarnings = [];
+
+    addDelta(
+        deltas,
+        "identity.workflowPath",
+        record.workflowPath,
+        EXPECTED_WORKFLOW_PATH,
+        record.workflowPath === EXPECTED_WORKFLOW_PATH,
+        "Use the standard caller workflow path.",
+    );
+    addDelta(
+        deltas,
+        "identity.workflowName",
+        record.workflowName,
+        EXPECTED_WORKFLOW_NAME,
+        record.workflowName === EXPECTED_WORKFLOW_NAME,
+        "Use the standard workflow name.",
+    );
+    addDelta(
+        deltas,
+        "triggers.events",
+        record.events,
+        REQUIRED_EVENTS,
+        equalArray(record.events, REQUIRED_EVENTS),
+        "Declare workflow_dispatch, schedule, push, and pull_request.",
+    );
+    addDelta(
+        deltas,
+        "triggers.schedule",
+        record.schedules,
+        "at least one schedule",
+        record.schedules.length > 0,
+        "Keep at least one repository-appropriate scheduled health run.",
+    );
+    addDelta(
+        deltas,
+        "triggers.push.branches",
+        record.pushBranches,
+        ["main"],
+        equalArray(record.pushBranches, ["main"]),
+        "Target the main branch for stable default-branch publication.",
+    );
+    addDelta(
+        deltas,
+        "triggers.push.filters",
+        {
+            branchesIgnore: record.pushBranchesIgnore,
+            paths: record.pushPaths,
+            pathsIgnore: record.pushPathsIgnore,
+        },
+        {},
+        record.pushBranchesIgnore.length === 0 &&
+            record.pushPaths.length === 0 &&
+            record.pushPathsIgnore.length === 0,
+        "Remove push filters that bypass reusable-workflow change evaluation.",
+    );
+    addDelta(
+        deltas,
+        "triggers.pullRequest.branches",
+        record.pullRequestBranches,
+        ["main"],
+        equalArray(record.pullRequestBranches, ["main"]),
+        "Target pull requests into main.",
+    );
+    addDelta(
+        deltas,
+        "triggers.pullRequest.types",
+        record.pullRequestTypes,
+        REQUIRED_PULL_REQUEST_TYPES,
+        equalArray(record.pullRequestTypes, REQUIRED_PULL_REQUEST_TYPES),
+        "Declare closed, opened, reopened, synchronize, labeled, and unlabeled.",
+    );
+    addDelta(
+        deltas,
+        "triggers.pullRequest.filters",
+        {
+            paths: record.pullRequestPaths,
+            pathsIgnore: record.pullRequestPathsIgnore,
+        },
+        {},
+        record.pullRequestPaths.length === 0 &&
+            record.pullRequestPathsIgnore.length === 0,
+        "Remove pull-request path filters that bypass Process-PSModule planning.",
+    );
+    addDelta(
+        deltas,
+        "concurrency.group",
+        record.concurrencyGroup,
+        EXPECTED_CONCURRENCY_GROUP,
+        record.concurrencyGroup === EXPECTED_CONCURRENCY_GROUP,
+        "Key concurrency by workflow and pull-request number or full ref.",
+    );
+    addDelta(
+        deltas,
+        "concurrency.cancelInProgress",
+        record.cancelInProgress,
+        EXPECTED_CANCEL_IN_PROGRESS,
+        record.cancelInProgress === EXPECTED_CANCEL_IN_PROGRESS,
+        "Cancel superseded pull-request runs only.",
+    );
+    addDelta(
+        deltas,
+        "permissions.workflow",
+        record.permissions,
+        {},
+        equalObject(record.permissions, {}),
+        "Set top-level permissions to an empty mapping.",
+    );
+    addDelta(
+        deltas,
+        "jobs.count",
+        record.processJobs.length,
+        1,
+        record.processJobs.length === 1,
+        "Keep exactly one Process-PSModule delegation job.",
+    );
+
+    for (const job of record.processJobs) {
+        addDelta(
+            deltas,
+            "job.name",
+            job.name,
+            EXPECTED_JOB_NAME,
+            job.name === EXPECTED_JOB_NAME,
+            "Use the standard Process-PSModule job identity.",
+        );
+        addDelta(
+            deltas,
+            "job.permissions",
+            job.permissions,
+            REQUIRED_JOB_PERMISSIONS,
+            equalObject(job.permissions, REQUIRED_JOB_PERMISSIONS),
+            "Grant only contents:read, pages:write, and id-token:write.",
+        );
+        addDelta(
+            deltas,
+            "job.condition",
+            job.condition,
+            null,
+            isEmptyCondition(job.condition),
+            "Remove the caller condition so the reusable workflow owns authorization.",
+        );
+        addDelta(
+            deltas,
+            "job.uses",
+            job.uses,
+            EXPECTED_USES,
+            job.uses === EXPECTED_USES,
+            "Pin the caller to the controlled v8 major reference.",
+        );
+        compareSecrets(job, deltas);
+        compareInputs(job, deltas, preservation);
+    }
+
+    if (record.additionalJobs.length > 0) {
+        reviewWarnings.push({
+            field: "additionalJobs",
+            value: record.additionalJobs,
+            instruction:
+                "Read each repository-owned job before migration and verify it cannot bypass the Process-PSModule trigger, concurrency, permission, or authorization boundary.",
+        });
+    }
+
+    const complete = missingFields.length === 0;
+    const compliant = complete && deltas.length === 0;
+    return {
+        repository: record.repository,
+        workflowPath: record.workflowPath,
+        status: complete
+            ? compliant
+                ? "compliant"
+                : "migration-needed"
+            : "incomplete",
+        compliant,
+        complete,
+        requestReady: complete,
+        missingFields,
+        deltas,
+        preservation,
+        reviewWarnings,
+    };
+}
+
+export function analyzeInventory(records) {
+    return records.map((record) => ({
+        ...record,
+        analysis: compareRepository(record),
+    }));
+}
+
+export function getSummary(state) {
+    const records = state.records ?? [];
+    const analyses = records.map((record) => record.analysis);
+    return {
+        inventoryStatus: state.inventoryStatus,
+        generatedAt: state.generatedAt ?? null,
+        organization: state.organization ?? null,
+        total: records.length,
+        parsed: records.filter((record) => record.status === "parsed").length,
+        parseErrors: analyses.filter((item) => item.status === "parse-error").length,
+        incomplete: analyses.filter((item) => item.status === "incomplete").length,
+        compliant: analyses.filter((item) => item.compliant).length,
+        migrationNeeded: analyses.filter(
+            (item) => item.status === "migration-needed",
+        ).length,
+        requestReady: analyses.filter(
+            (item) => item.requestReady && !item.compliant,
+        ).length,
+        selected: state.selection?.length ?? 0,
+        error: state.error ?? null,
+    };
+}
+
+export function buildMigrationRequest(records) {
+    if (!Array.isArray(records) || records.length === 0) {
+        throw new Error("Select at least one repository before requesting migration.");
+    }
+
+    const blocked = records.filter((record) => !record.analysis.requestReady);
+    if (blocked.length > 0) {
+        throw new Error(
+            `Migration request blocked because inventory is incomplete for: ${blocked
+                .map((record) => record.repository)
+                .join(", ")}.`,
+        );
+    }
+
+    return {
+        schemaVersion: 1,
+        target: TARGET_CONTRACT,
+        repositories: records.map((record) => ({
+            repository: record.repository,
+            defaultBranch: record.defaultBranch,
+            workflowPath: record.workflowPath,
+            workflowUrl: record.workflowUrl,
+            currentReferences: record.processJobs.map((job) => job.reference),
+            deltas: record.analysis.deltas,
+            preserve: record.analysis.preservation,
+            reviewWarnings: record.analysis.reviewWarnings,
+        })),
+    };
+}
+
+export function buildMigrationPrompt(request) {
+    const repositoryNames = request.repositories
+        .map((record) => record.repository)
+        .join(", ");
+    return `Orchestrate the Process-PSModule v8 caller migration for these repositories: ${repositoryNames}.
+
+Invoke the orchestrate skill and follow the MSX fleet orchestration and contribution workflows. Create exactly one coordinated child project session per selected repository. In each repository:
+
+1. Refresh and read the target repository's default-branch caller workflow before editing; do not trust this snapshot as the source of truth.
+2. Create one repository-scoped delivery branch and open one draft pull request early. Adopt a matching open pull request instead of creating a duplicate.
+3. Preserve valid repository-specific schedule timing, optional TestData JSON, and valid ImportantFilePatterns, SettingsPath, WorkingDirectory, Version, Prerelease, or Verbose behavior after verifying each value against the current repository and reusable-workflow interface.
+4. Apply the agreed caller identity, trigger, concurrency, permission, unconditional-call, explicit-secret, and @v8 contract from the structured request below. Do not set Debug: true.
+5. Read every additional repository-owned job and verify it cannot bypass the Process-PSModule trigger, concurrency, permission, or authorization boundary. Stop and report a blocker instead of guessing when inventory or workflow parsing is incomplete.
+6. Run the repository-native validation and the applicable review loop. Report every child session, branch, validation result, blocker, and draft pull request URL to this parent session.
+
+Do not batch repositories into one branch or pull request. Do not mutate repositories from outside their child sessions.
+
+Structured migration request:
+
+\`\`\`json
+${JSON.stringify(request, null, 2)}
+\`\`\``;
+}

--- a/.github/extensions/process-workflow-fleet/fleet-model.test.mjs
+++ b/.github/extensions/process-workflow-fleet/fleet-model.test.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+    analyzeInventory,
+    buildMigrationPrompt,
+    buildMigrationRequest,
+    compareRepository,
+    normalizeInventory,
+} from "./fleet-model.mjs";
+
+function createRecord(overrides = {}) {
+    return {
+        Repository: "PSModule/Example",
+        DefaultBranch: "main",
+        Archived: false,
+        RepositoryUrl: "https://github.com/PSModule/Example",
+        WorkflowPath: ".github/workflows/Process-PSModule.yml",
+        WorkflowUrl:
+            "https://github.com/PSModule/Example/blob/main/.github/workflows/Process-PSModule.yml",
+        Status: "Parsed",
+        Error: null,
+        WorkflowName: "Process-PSModule",
+        RunName: null,
+        Events: ["pull_request", "push", "schedule", "workflow_dispatch"],
+        Schedules: ["0 0 * * *"],
+        PushBranches: ["main"],
+        PushBranchesIgnore: [],
+        PushPaths: [],
+        PushPathsIgnore: [],
+        PullRequestBranches: ["main"],
+        PullRequestTypes: [
+            "closed",
+            "opened",
+            "reopened",
+            "synchronize",
+            "labeled",
+            "unlabeled",
+        ],
+        PullRequestPaths: [],
+        PullRequestPathsIgnore: [],
+        ConcurrencyGroup:
+            "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+        CancelInProgress: "${{ github.event_name == 'pull_request' }}",
+        Permissions: {},
+        ProcessJobs: [
+            {
+                Name: "Process-PSModule",
+                Uses: "PSModule/Process-PSModule/.github/workflows/workflow.yml@v8",
+                Reference: "v8",
+                Inputs: {},
+                SecretMode: "explicit",
+                SecretMappings: {
+                    PSGALLERY_API_KEY: "${{ secrets.PSGALLERY_API_KEY }}",
+                    GitHubAppClientId: "${{ secrets.SHELLY_CLIENT_ID }}",
+                    GitHubAppPrivateKey: "${{ secrets.SHELLY_PRIVATE_KEY }}",
+                },
+                Permissions: {
+                    contents: "read",
+                    pages: "write",
+                    "id-token": "write",
+                },
+                Environment: null,
+                Condition: null,
+            },
+        ],
+        AdditionalJobs: [],
+        VersionComments: [{ Reference: "v8", Version: "v8.0.1" }],
+        ...overrides,
+    };
+}
+
+describe("inventory normalization and comparison", () => {
+    it("recognizes the agreed v8 caller contract", () => {
+        const [record] = normalizeInventory([createRecord()]);
+        const analysis = compareRepository(record);
+
+        assert.equal(record.repository, "PSModule/Example");
+        assert.equal(analysis.status, "compliant");
+        assert.equal(analysis.compliant, true);
+        assert.deepEqual(analysis.deltas, []);
+    });
+
+    it("reports migration deltas and preserves supported optional behavior", () => {
+        const source = createRecord({
+            Events: ["pull_request", "schedule", "workflow_dispatch"],
+            ProcessJobs: [
+                {
+                    ...createRecord().ProcessJobs[0],
+                    Uses: "PSModule/Process-PSModule/.github/workflows/workflow.yml@v6",
+                    Reference: "v6",
+                    Inputs: {
+                        Debug: true,
+                        ImportantFilePatterns: '["src/**","README.md"]',
+                    },
+                    SecretMappings: {
+                        PSGALLERY_API_KEY: "${{ secrets.PSGALLERY_API_KEY }}",
+                        GitHubAppClientId: "${{ secrets.SHELLY_CLIENT_ID }}",
+                        GitHubAppPrivateKey: "${{ secrets.SHELLY_PRIVATE_KEY }}",
+                        TestData:
+                            '{"secrets":{"TOKEN":"${{ secrets.TEST_TOKEN }}"}}',
+                    },
+                },
+            ],
+        });
+        const [record] = analyzeInventory(normalizeInventory(source));
+
+        assert.equal(record.analysis.status, "migration-needed");
+        assert.ok(
+            record.analysis.deltas.some((delta) => delta.field === "job.uses"),
+        );
+        assert.ok(
+            record.analysis.deltas.some(
+                (delta) => delta.field === "job.inputs.Debug",
+            ),
+        );
+        assert.deepEqual(
+            record.analysis.preservation.map((item) => item.field).sort(),
+            ["job.inputs.ImportantFilePatterns", "job.secrets.TestData"],
+        );
+    });
+
+    it("fails closed when the inventory contract is incomplete", () => {
+        const source = createRecord();
+        delete source.PullRequestPaths;
+        const [record] = analyzeInventory(normalizeInventory(source));
+
+        assert.equal(record.analysis.status, "incomplete");
+        assert.equal(record.analysis.requestReady, false);
+        assert.deepEqual(record.analysis.missingFields, ["PullRequestPaths"]);
+        assert.throws(
+            () => buildMigrationRequest([record]),
+            /inventory is incomplete/,
+        );
+    });
+
+    it("fails closed on parse errors", () => {
+        const [record] = analyzeInventory(
+            normalizeInventory({
+                Repository: "PSModule/Broken",
+                WorkflowPath: ".github/workflows/Process-PSModule.yml",
+                Status: "ParseError",
+                Error: "Unexpected token",
+            }),
+        );
+
+        assert.equal(record.analysis.status, "parse-error");
+        assert.equal(record.analysis.requestReady, false);
+    });
+});
+
+describe("migration request generation", () => {
+    it("creates a complete orchestration prompt without mutating repositories", () => {
+        const [record] = analyzeInventory(normalizeInventory(createRecord()));
+        const request = buildMigrationRequest([record]);
+        const prompt = buildMigrationPrompt(request);
+
+        assert.match(prompt, /exactly one coordinated child project session/);
+        assert.match(prompt, /open one draft pull request early/);
+        assert.match(prompt, /refresh and read/i);
+        assert.match(prompt, /ImportantFilePatterns/);
+        assert.match(prompt, /workflow\.yml@v8/);
+        assert.match(prompt, /repository-native validation/);
+        assert.match(prompt, /PSModule\/Example/);
+    });
+
+    it("rejects an empty repository selection", () => {
+        assert.throws(
+            () => buildMigrationRequest([]),
+            /Select at least one repository/,
+        );
+    });
+});

--- a/.github/extensions/process-workflow-fleet/fleet-service.mjs
+++ b/.github/extensions/process-workflow-fleet/fleet-service.mjs
@@ -251,6 +251,23 @@ export function createFleetService({ getSession, repositoryRoot }) {
                     `Unsupported or mismatched state at ${statePath()}.`,
                 );
             }
+            if (
+                state.inventoryStatus === "refreshing" &&
+                !refreshes.has(identity)
+            ) {
+                return writeState({
+                    ...state,
+                    inventoryStatus: "not-refreshed",
+                    generatedAt: null,
+                    error: {
+                        code: "inventory_refresh_interrupted",
+                        message:
+                            "The previous inventory refresh was interrupted. Refresh again.",
+                    },
+                    records: [],
+                    selection: [],
+                });
+            }
             return state;
         } catch (error) {
             if (error?.code === "ENOENT") {

--- a/.github/extensions/process-workflow-fleet/fleet-service.mjs
+++ b/.github/extensions/process-workflow-fleet/fleet-service.mjs
@@ -1,0 +1,672 @@
+import { execFile, execFileSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import {
+    mkdir,
+    readFile,
+    rename,
+    rm,
+    writeFile,
+} from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import {
+    dirname,
+    isAbsolute,
+    join,
+    resolve,
+} from "node:path";
+import { promisify } from "node:util";
+
+import {
+    analyzeInventory,
+    buildMigrationPrompt,
+    buildMigrationRequest,
+    getSummary,
+    normalizeInventory,
+} from "./fleet-model.mjs";
+import { renderDashboard } from "./renderer.mjs";
+
+const execFileAsync = promisify(execFile);
+const STATE_VERSION = 1;
+const MAX_REQUEST_BYTES = 1024 * 1024;
+const servers = new Map();
+const refreshes = new Map();
+
+let createCanvasError = (code, message) => {
+    const error = new Error(message);
+    error.code = code;
+    return error;
+};
+
+function pathLooksLikeRepository(candidate) {
+    try {
+        const root = execFileSync(
+            "git",
+            ["-C", candidate, "rev-parse", "--show-toplevel"],
+            {
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "ignore"],
+            },
+        ).trim();
+        return root || null;
+    } catch (error) {
+        if (
+            error &&
+            typeof error === "object" &&
+            hasOwn(error, "status") &&
+            error.status !== 0
+        ) {
+            return null;
+        }
+        throw error;
+    }
+}
+
+function hasOwn(value, property) {
+    return (
+        value !== null &&
+        typeof value === "object" &&
+        Object.prototype.hasOwnProperty.call(value, property)
+    );
+}
+
+export function resolveRepositoryRoot({
+    currentWorkingDirectory,
+    moduleDirectory,
+    sessionWorkspacePath,
+} = {}) {
+    const candidates = [
+        currentWorkingDirectory,
+        process.env.GITHUB_WORKSPACE,
+        process.env.COPILOT_WORKSPACE_PATH,
+        sessionWorkspacePath,
+        moduleDirectory,
+    ].filter(Boolean);
+
+    for (const candidate of candidates) {
+        const root = pathLooksLikeRepository(resolve(candidate));
+        if (root) {
+            return root;
+        }
+    }
+
+    throw new Error(
+        `Could not locate the repository root from: ${candidates.join(", ")}.`,
+    );
+}
+
+function workspaceIdentity(repositoryRoot) {
+    return createHash("sha256")
+        .update(resolve(repositoryRoot).toLowerCase())
+        .digest("hex")
+        .slice(0, 16);
+}
+
+function sanitizeDiagnostic(value) {
+    return String(value ?? "")
+        .replace(
+            /\b(?:gh[opurs]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+)\b/g,
+            "[REDACTED_TOKEN]",
+        )
+        .replace(
+            /(GH_TOKEN|GITHUB_TOKEN|PSGALLERY_API_KEY)\s*[:=]\s*\S+/gi,
+            "$1=[REDACTED]",
+        )
+        .trim();
+}
+
+function initialState(repositoryRoot, organization = "PSModule") {
+    return {
+        stateVersion: STATE_VERSION,
+        workspaceIdentity: workspaceIdentity(repositoryRoot),
+        repositoryRoot,
+        organization,
+        inventoryStatus: "not-refreshed",
+        generatedAt: null,
+        command: null,
+        error: null,
+        records: [],
+        selection: [],
+    };
+}
+
+function responseJson(response, statusCode, value) {
+    response.writeHead(statusCode, {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Content-Type-Options": "nosniff",
+    });
+    response.end(JSON.stringify(value));
+}
+
+function responseHtml(response, html) {
+    response.writeHead(200, {
+        "Cache-Control": "no-store",
+        "Content-Security-Policy":
+            "default-src 'self'; connect-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'self'",
+        "Content-Type": "text/html; charset=utf-8",
+        "Referrer-Policy": "no-referrer",
+        "X-Content-Type-Options": "nosniff",
+    });
+    response.end(html);
+}
+
+async function readRequestJson(request) {
+    let size = 0;
+    const chunks = [];
+    for await (const chunk of request) {
+        size += chunk.length;
+        if (size > MAX_REQUEST_BYTES) {
+            throw createCanvasError(
+                "request_too_large",
+                `Canvas request exceeds ${MAX_REQUEST_BYTES} bytes.`,
+            );
+        }
+        chunks.push(chunk);
+    }
+    if (chunks.length === 0) {
+        return {};
+    }
+    try {
+        return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    } catch (error) {
+        throw createCanvasError(
+            "request_json_invalid",
+            `Canvas request JSON is invalid: ${sanitizeDiagnostic(error.message)}`,
+        );
+    }
+}
+
+function requireCanvasToken(request, token) {
+    if (request.headers["x-canvas-token"] !== token) {
+        throw createCanvasError(
+            "canvas_request_forbidden",
+            "Canvas request token is missing or invalid.",
+        );
+    }
+}
+
+async function closeHttpServer(server) {
+    await new Promise((resolveClose, rejectClose) => {
+        server.close((error) => {
+            if (error) {
+                rejectClose(error);
+            } else {
+                resolveClose();
+            }
+        });
+    });
+}
+
+export function createFleetService({ getSession, repositoryRoot }) {
+    const identity = workspaceIdentity(repositoryRoot);
+
+    function stateDirectory() {
+        const sessionWorkspacePath = getSession()?.workspacePath;
+        if (sessionWorkspacePath) {
+            return join(
+                sessionWorkspacePath,
+                "files",
+                "process-workflow-fleet",
+                identity,
+            );
+        }
+        return join(tmpdir(), "copilot-process-workflow-fleet", identity);
+    }
+
+    function statePath() {
+        return join(stateDirectory(), "state.json");
+    }
+
+    function inventoryPath() {
+        return join(stateDirectory(), "inventory.json");
+    }
+
+    async function writeState(state) {
+        const directory = stateDirectory();
+        await mkdir(directory, { recursive: true });
+        const path = statePath();
+        const temporaryPath = `${path}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+        try {
+            await writeFile(
+                temporaryPath,
+                `${JSON.stringify(state, null, 2)}\n`,
+                "utf8",
+            );
+            await rename(temporaryPath, path);
+        } finally {
+            await rm(temporaryPath, { force: true });
+        }
+        return state;
+    }
+
+    async function readState() {
+        try {
+            const state = JSON.parse(await readFile(statePath(), "utf8"));
+            if (
+                state.stateVersion !== STATE_VERSION ||
+                state.workspaceIdentity !== identity
+            ) {
+                throw new Error(
+                    `Unsupported or mismatched state at ${statePath()}.`,
+                );
+            }
+            return state;
+        } catch (error) {
+            if (error?.code === "ENOENT") {
+                return null;
+            }
+            throw createCanvasError(
+                "fleet_state_read_failed",
+                `Could not read workflow fleet state at ${statePath()}: ${sanitizeDiagnostic(error.message)}`,
+            );
+        }
+    }
+
+    async function ensureState({ organization } = {}) {
+        const existing = await readState();
+        if (existing) {
+            if (organization && organization !== existing.organization) {
+                return writeState({
+                    ...initialState(repositoryRoot, organization),
+                    selection: [],
+                });
+            }
+            return existing;
+        }
+        return writeState(initialState(repositoryRoot, organization));
+    }
+
+    function inventoryCommand(input, outputPath) {
+        const organization = input.organization || "PSModule";
+        const scriptPath = join(
+            repositoryRoot,
+            ".github",
+            "scripts",
+            "Get-ProcessPSModuleWorkflowInventory.ps1",
+        );
+        if (!isAbsolute(scriptPath)) {
+            throw createCanvasError(
+                "inventory_script_path_invalid",
+                `Inventory script path is not absolute: ${scriptPath}`,
+            );
+        }
+        const args = [
+            "-NoLogo",
+            "-NoProfile",
+            "-File",
+            scriptPath,
+            "-Organization",
+            organization,
+        ];
+        if (input.repositories?.length) {
+            args.push("-Repository", ...input.repositories);
+        }
+        args.push("-TargetReference", "v8", "-JsonPath", outputPath);
+        if (input.includeArchived === true) {
+            args.push("-IncludeArchived");
+        }
+        return {
+            executable: "pwsh",
+            args,
+            organization,
+            repositories: input.repositories ?? [],
+            display: `pwsh -NoLogo -NoProfile -File ${scriptPath} -Organization ${organization}${input.repositories?.length ? ` -Repository ${input.repositories.join(",")}` : ""} -TargetReference v8 -JsonPath ${outputPath}${input.includeArchived ? " -IncludeArchived" : ""}`,
+        };
+    }
+
+    async function loadGeneratedInventory() {
+        const content = await readFile(inventoryPath(), "utf8");
+        const parsed = JSON.parse(content.replace(/^\uFEFF/, ""));
+        const records = analyzeInventory(normalizeInventory(parsed));
+        if (records.length === 0) {
+            throw new Error(
+                `Inventory command wrote no workflow records to ${inventoryPath()}.`,
+            );
+        }
+        return records;
+    }
+
+    async function refreshInventory(input = {}) {
+        if (refreshes.has(identity)) {
+            throw createCanvasError(
+                "inventory_refresh_in_progress",
+                "A workflow inventory refresh is already running for this workspace.",
+            );
+        }
+
+        const refresh = (async () => {
+            const previous = await ensureState({
+                organization: input.organization,
+            });
+            const command = inventoryCommand(
+                {
+                    ...input,
+                    organization: input.organization || previous.organization,
+                },
+                inventoryPath(),
+            );
+            await rm(inventoryPath(), { force: true });
+            await writeState({
+                ...previous,
+                organization: command.organization,
+                inventoryStatus: "refreshing",
+                generatedAt: null,
+                command: command.display,
+                error: null,
+                records: [],
+                selection: [],
+            });
+
+            try {
+                await execFileAsync(command.executable, command.args, {
+                    cwd: repositoryRoot,
+                    encoding: "utf8",
+                    maxBuffer: 10 * 1024 * 1024,
+                    windowsHide: true,
+                });
+                const records = await loadGeneratedInventory();
+                const state = await writeState({
+                    ...previous,
+                    organization: command.organization,
+                    inventoryStatus: "ready",
+                    generatedAt: new Date().toISOString(),
+                    command: command.display,
+                    error: null,
+                    records,
+                    selection: [],
+                });
+                return {
+                    summary: getSummary(state),
+                    artifactPath: inventoryPath(),
+                };
+            } catch (error) {
+                let records = [];
+                try {
+                    records = await loadGeneratedInventory();
+                } catch (artifactError) {
+                    if (artifactError?.code !== "ENOENT") {
+                        error.message = `${error.message}; generated inventory could not be read: ${artifactError.message}`;
+                    }
+                }
+
+                const diagnostic = sanitizeDiagnostic(
+                    error.stderr || error.stdout || error.message,
+                );
+                const failure = await writeState({
+                    ...previous,
+                    organization: command.organization,
+                    inventoryStatus: "failed",
+                    generatedAt: new Date().toISOString(),
+                    command: command.display,
+                    error: {
+                        code: "inventory_refresh_failed",
+                        message: diagnostic,
+                        organization: command.organization,
+                        repositories: command.repositories,
+                    },
+                    records,
+                    selection: [],
+                });
+                getSession()?.log(
+                    `Process workflow fleet refresh failed for ${command.organization}: ${diagnostic}`,
+                    { level: "error", ephemeral: false },
+                );
+                throw createCanvasError(
+                    "inventory_refresh_failed",
+                    `Inventory command failed for ${command.organization}: ${diagnostic}. State: ${statePath()}`,
+                );
+            }
+        })();
+
+        refreshes.set(identity, refresh);
+        try {
+            return await refresh;
+        } finally {
+            refreshes.delete(identity);
+        }
+    }
+
+    async function getSummaryResult() {
+        return getSummary(await ensureState());
+    }
+
+    async function getRepository(repository) {
+        const state = await ensureState();
+        const record = state.records.find(
+            (item) => item.repository === repository,
+        );
+        if (!record) {
+            throw createCanvasError(
+                "repository_not_found",
+                `Repository [${repository}] is not present in the current inventory.`,
+            );
+        }
+        return record;
+    }
+
+    async function setSelection(repositories) {
+        const state = await ensureState();
+        if (state.inventoryStatus !== "ready") {
+            throw createCanvasError(
+                "inventory_not_ready",
+                "Refresh inventory successfully before selecting repositories.",
+            );
+        }
+        const known = new Set(state.records.map((record) => record.repository));
+        const unknown = repositories.filter((repository) => !known.has(repository));
+        if (unknown.length > 0) {
+            throw createCanvasError(
+                "selection_repository_unknown",
+                `Selection contains repositories outside the current inventory: ${unknown.join(", ")}.`,
+            );
+        }
+        const selection = [...new Set(repositories)].sort();
+        await writeState({
+            ...state,
+            selection,
+        });
+        return {
+            repositories: selection,
+            count: selection.length,
+        };
+    }
+
+    async function requestMigration({
+        repositories,
+        dryRun = true,
+        confirmed = false,
+    } = {}) {
+        const state = await ensureState();
+        if (state.inventoryStatus !== "ready") {
+            throw createCanvasError(
+                "inventory_not_ready",
+                "Migration requests require a successful current inventory refresh.",
+            );
+        }
+        const selection = repositories ?? state.selection;
+        if (!selection || selection.length === 0) {
+            throw createCanvasError(
+                "migration_selection_empty",
+                "Select at least one repository before requesting migration.",
+            );
+        }
+        const selected = selection.map((repository) => {
+            const record = state.records.find(
+                (item) => item.repository === repository,
+            );
+            if (!record) {
+                throw createCanvasError(
+                    "migration_repository_unknown",
+                    `Repository [${repository}] is not present in the current inventory.`,
+                );
+            }
+            return record;
+        });
+
+        let request;
+        try {
+            request = buildMigrationRequest(selected);
+        } catch (error) {
+            throw createCanvasError(
+                "migration_inventory_incomplete",
+                error.message,
+            );
+        }
+        const prompt = buildMigrationPrompt(request);
+
+        if (dryRun !== false) {
+            return {
+                dryRun: true,
+                sent: false,
+                request,
+                prompt,
+            };
+        }
+        if (confirmed !== true) {
+            throw createCanvasError(
+                "migration_confirmation_required",
+                "Set confirmed to true only after the user explicitly confirms the migration request.",
+            );
+        }
+
+        const activeSession = getSession();
+        if (!activeSession) {
+            throw createCanvasError(
+                "session_unavailable",
+                "The active Copilot session is not available for migration orchestration.",
+            );
+        }
+        const messageId = await activeSession.send({ prompt });
+        return {
+            dryRun: false,
+            sent: true,
+            messageId,
+            repositories: selection,
+        };
+    }
+
+    async function handleHttpRequest(request, response, token) {
+        const url = new URL(request.url ?? "/", "http://127.0.0.1");
+        if (request.method === "GET" && url.pathname === "/") {
+            responseHtml(response, renderDashboard(token));
+            return;
+        }
+        if (request.method === "GET" && url.pathname === "/api/state") {
+            responseJson(response, 200, await ensureState());
+            return;
+        }
+        if (request.method !== "POST") {
+            responseJson(response, 404, {
+                error: {
+                    code: "route_not_found",
+                    message: `No canvas route for ${request.method} ${url.pathname}.`,
+                },
+            });
+            return;
+        }
+
+        requireCanvasToken(request, token);
+        const input = await readRequestJson(request);
+        if (url.pathname === "/api/refresh") {
+            responseJson(response, 200, await refreshInventory(input));
+            return;
+        }
+        if (url.pathname === "/api/selection") {
+            responseJson(
+                response,
+                200,
+                await setSelection(input.repositories ?? []),
+            );
+            return;
+        }
+        if (url.pathname === "/api/migration") {
+            responseJson(response, 200, await requestMigration(input));
+            return;
+        }
+        responseJson(response, 404, {
+            error: {
+                code: "route_not_found",
+                message: `No canvas route for POST ${url.pathname}.`,
+            },
+        });
+    }
+
+    async function openPanel(instanceId) {
+        const existing = servers.get(instanceId);
+        if (existing) {
+            return existing;
+        }
+
+        const token = randomBytes(24).toString("base64url");
+        const server = createServer((request, response) => {
+            handleHttpRequest(request, response, token).catch((error) => {
+                const code = error.code || "canvas_http_failed";
+                const message = sanitizeDiagnostic(error.message);
+                getSession()?.log(
+                    `Process workflow fleet request failed: ${message}`,
+                    { level: "error", ephemeral: true },
+                );
+                if (!response.headersSent) {
+                    responseJson(response, code === "route_not_found" ? 404 : 500, {
+                        error: { code, message },
+                    });
+                } else {
+                    response.end();
+                }
+            });
+        });
+        server.on("clientError", (error, socket) => {
+            getSession()?.log(
+                `Process workflow fleet HTTP client error: ${sanitizeDiagnostic(error.message)}`,
+                { level: "warning", ephemeral: true },
+            );
+            socket.end("HTTP/1.1 400 Bad Request\r\n\r\n");
+        });
+        await new Promise((resolveListen, rejectListen) => {
+            server.once("error", rejectListen);
+            server.listen(0, "127.0.0.1", () => {
+                server.off("error", rejectListen);
+                resolveListen();
+            });
+        });
+        const address = server.address();
+        if (!address || typeof address === "string") {
+            await closeHttpServer(server);
+            throw createCanvasError(
+                "canvas_server_address_invalid",
+                "Loopback canvas server did not return a TCP address.",
+            );
+        }
+        const entry = {
+            server,
+            token,
+            url: `http://127.0.0.1:${address.port}/`,
+        };
+        servers.set(instanceId, entry);
+        return entry;
+    }
+
+    async function closePanel(instanceId) {
+        const entry = servers.get(instanceId);
+        if (!entry) {
+            return;
+        }
+        servers.delete(instanceId);
+        await closeHttpServer(entry.server);
+    }
+
+    return {
+        closePanel,
+        ensureState,
+        getRepository,
+        getSummary: getSummaryResult,
+        openPanel,
+        refreshInventory,
+        requestMigration,
+        setCanvasErrorFactory(factory) {
+            createCanvasError = factory;
+        },
+        setSelection,
+    };
+}

--- a/.github/extensions/process-workflow-fleet/fleet-service.mjs
+++ b/.github/extensions/process-workflow-fleet/fleet-service.mjs
@@ -546,14 +546,14 @@ export function createFleetService({ getSession, repositoryRoot }) {
         };
     }
 
-    async function handleHttpRequest(request, response, token) {
+    async function handleHttpRequest(request, response, token, organization) {
         const url = new URL(request.url ?? "/", "http://127.0.0.1");
         if (request.method === "GET" && url.pathname === "/") {
             responseHtml(response, renderDashboard(token));
             return;
         }
         if (request.method === "GET" && url.pathname === "/api/state") {
-            responseJson(response, 200, await ensureState());
+            responseJson(response, 200, await ensureState({ organization }));
             return;
         }
         if (request.method !== "POST") {
@@ -592,7 +592,7 @@ export function createFleetService({ getSession, repositoryRoot }) {
         });
     }
 
-    async function openPanel(instanceId) {
+    async function openPanel(instanceId, { organization } = {}) {
         const existing = servers.get(instanceId);
         if (existing) {
             return existing;
@@ -600,21 +600,27 @@ export function createFleetService({ getSession, repositoryRoot }) {
 
         const token = randomBytes(24).toString("base64url");
         const server = createServer((request, response) => {
-            handleHttpRequest(request, response, token).catch((error) => {
-                const code = error.code || "canvas_http_failed";
-                const message = sanitizeDiagnostic(error.message);
-                getSession()?.log(
-                    `Process workflow fleet request failed: ${message}`,
-                    { level: "error", ephemeral: true },
-                );
-                if (!response.headersSent) {
-                    responseJson(response, code === "route_not_found" ? 404 : 500, {
-                        error: { code, message },
-                    });
-                } else {
-                    response.end();
-                }
-            });
+            handleHttpRequest(request, response, token, organization).catch(
+                (error) => {
+                    const code = error.code || "canvas_http_failed";
+                    const message = sanitizeDiagnostic(error.message);
+                    getSession()?.log(
+                        `Process workflow fleet request failed: ${message}`,
+                        { level: "error", ephemeral: true },
+                    );
+                    if (!response.headersSent) {
+                        responseJson(
+                            response,
+                            code === "route_not_found" ? 404 : 500,
+                            {
+                                error: { code, message },
+                            },
+                        );
+                    } else {
+                        response.end();
+                    }
+                },
+            );
         });
         server.on("clientError", (error, socket) => {
             getSession()?.log(

--- a/.github/extensions/process-workflow-fleet/renderer.mjs
+++ b/.github/extensions/process-workflow-fleet/renderer.mjs
@@ -1,0 +1,712 @@
+function serializeForInlineScript(value) {
+    return JSON.stringify(value).replaceAll("<", "\\u003c");
+}
+
+export function renderDashboard(token) {
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Process workflow fleet</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      background: var(--background-color-default, #ffffff);
+      color: var(--text-color-default, #1f2328);
+      font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+      font-size: var(--text-body-medium, 14px);
+      line-height: var(--leading-body-medium, 20px);
+    }
+    button,
+    input,
+    select {
+      font: inherit;
+    }
+    button {
+      border: 1px solid var(--border-color-default, #d0d7de);
+      border-radius: 6px;
+      padding: 6px 12px;
+      background: var(--background-color-default, #ffffff);
+      color: var(--text-color-default, #1f2328);
+      cursor: pointer;
+    }
+    button:hover:not(:disabled) {
+      background: var(--background-color-muted, #f6f8fa);
+    }
+    button:focus-visible,
+    input:focus-visible,
+    select:focus-visible {
+      outline: 2px solid var(--color-focus-outline, #0969da);
+      outline-offset: 2px;
+    }
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+    .primary {
+      border-color: var(--true-color-blue, #0969da);
+      background: var(--true-color-blue, #0969da);
+      color: var(--color-white, #ffffff);
+    }
+    .app {
+      min-height: 100vh;
+      display: grid;
+      grid-template-rows: auto auto auto 1fr auto;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--border-color-default, #d0d7de);
+    }
+    h1,
+    h2,
+    h3 {
+      margin: 0;
+      font-weight: var(--font-weight-semibold, 600);
+    }
+    h1 {
+      font-size: var(--text-title-large, 26px);
+      line-height: var(--leading-title-large, 32px);
+    }
+    h2 {
+      font-size: var(--text-title-medium, 18px);
+      line-height: var(--leading-title-medium, 24px);
+    }
+    h3 {
+      font-size: var(--text-body-medium, 14px);
+    }
+    .muted {
+      color: var(--text-color-muted, #656d76);
+    }
+    .status {
+      padding: 10px 20px;
+      border-bottom: 1px solid var(--border-color-default, #d0d7de);
+    }
+    .status[data-kind="error"] {
+      background: var(--true-color-red-muted, #ffebe9);
+      color: var(--true-color-red, #cf222e);
+    }
+    .status[data-kind="success"] {
+      background: var(--true-color-blue-muted, #ddf4ff);
+    }
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 8px;
+      padding: 12px 20px;
+      border-bottom: 1px solid var(--border-color-default, #d0d7de);
+    }
+    .metric {
+      border: 1px solid var(--border-color-default, #d0d7de);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: var(--background-color-muted, #f6f8fa);
+    }
+    .metric strong {
+      display: block;
+      font-size: var(--text-title-medium, 18px);
+    }
+    .workspace {
+      min-height: 0;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 34%);
+    }
+    .fleet {
+      min-width: 0;
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr);
+      border-right: 1px solid var(--border-color-default, #d0d7de);
+    }
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 12px;
+      border-bottom: 1px solid var(--border-color-default, #d0d7de);
+    }
+    .toolbar input {
+      min-width: 220px;
+      flex: 1;
+    }
+    input,
+    select {
+      border: 1px solid var(--border-color-default, #d0d7de);
+      border-radius: 6px;
+      padding: 6px 8px;
+      background: var(--background-color-default, #ffffff);
+      color: var(--text-color-default, #1f2328);
+    }
+    .table-wrap {
+      overflow: auto;
+    }
+    table {
+      width: 100%;
+      min-width: 1500px;
+      border-collapse: collapse;
+    }
+    th,
+    td {
+      padding: 8px;
+      border-bottom: 1px solid var(--border-color-default, #d0d7de);
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      background: var(--background-color-muted, #f6f8fa);
+      white-space: nowrap;
+    }
+    tbody tr {
+      cursor: pointer;
+    }
+    tbody tr:hover,
+    tbody tr[data-active="true"] {
+      background: var(--background-color-muted, #f6f8fa);
+    }
+    code,
+    pre {
+      font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);
+      font-size: var(--text-code-inline, 12px);
+    }
+    td code {
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+    .badge {
+      display: inline-block;
+      border: 1px solid var(--border-color-default, #d0d7de);
+      border-radius: 999px;
+      padding: 1px 7px;
+      white-space: nowrap;
+    }
+    .badge[data-status="compliant"] {
+      border-color: var(--true-color-blue, #0969da);
+    }
+    .badge[data-status="parse-error"],
+    .badge[data-status="incomplete"] {
+      border-color: var(--true-color-red, #cf222e);
+      color: var(--true-color-red, #cf222e);
+    }
+    aside {
+      min-width: 0;
+      overflow: auto;
+      padding: 16px;
+    }
+    .detail-section {
+      margin-top: 16px;
+    }
+    .delta {
+      margin-top: 8px;
+      padding: 10px;
+      border: 1px solid var(--border-color-default, #d0d7de);
+      border-radius: 8px;
+    }
+    .delta pre {
+      margin: 6px 0 0;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      color: var(--text-color-muted, #656d76);
+    }
+    footer {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 20px;
+      border-top: 1px solid var(--border-color-default, #d0d7de);
+    }
+    footer label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-right: auto;
+    }
+    .empty {
+      padding: 32px;
+      text-align: center;
+      color: var(--text-color-muted, #656d76);
+    }
+    @media (max-width: 900px) {
+      .workspace {
+        grid-template-columns: 1fr;
+      }
+      .fleet {
+        border-right: 0;
+      }
+      aside {
+        border-top: 1px solid var(--border-color-default, #d0d7de);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <header>
+      <div>
+        <h1>Process workflow fleet</h1>
+        <div class="muted">Authenticated evidence and explicit v8 migration deltas</div>
+      </div>
+      <button class="primary" id="refresh">Refresh inventory</button>
+    </header>
+    <div class="status" id="status" role="status" aria-live="polite">Loading workspace state…</div>
+    <section class="summary" id="summary" aria-label="Fleet summary"></section>
+    <main class="workspace">
+      <section class="fleet">
+        <div class="toolbar">
+          <input id="search" type="search" placeholder="Search repositories and workflow paths" aria-label="Search repositories">
+          <select id="filter" aria-label="Filter by compliance status">
+            <option value="">All statuses</option>
+            <option value="compliant">Compliant</option>
+            <option value="migration-needed">Migration needed</option>
+            <option value="incomplete">Incomplete</option>
+            <option value="parse-error">Parse error</option>
+          </select>
+          <button id="select-visible">Select visible</button>
+          <button id="clear-selection">Clear selection</button>
+        </div>
+        <div class="table-wrap">
+          <table aria-label="Process-PSModule caller workflow inventory">
+            <thead>
+              <tr>
+                <th scope="col">Select</th>
+                <th scope="col">Repository</th>
+                <th scope="col">Workflow</th>
+                <th scope="col">Reference / compliance</th>
+                <th scope="col">Triggers</th>
+                <th scope="col">Concurrency</th>
+                <th scope="col">Permissions</th>
+                <th scope="col">Condition</th>
+                <th scope="col">Secrets</th>
+                <th scope="col">Inputs</th>
+                <th scope="col">Extra jobs</th>
+              </tr>
+            </thead>
+            <tbody id="rows"></tbody>
+          </table>
+          <div class="empty" id="empty" hidden>No repositories match this view.</div>
+        </div>
+      </section>
+      <aside id="inspector">
+        <h2>Migration delta</h2>
+        <p class="muted">Select a repository row to inspect its evidence and migration plan.</p>
+      </aside>
+    </main>
+    <footer>
+      <label>
+        <input type="checkbox" id="confirm">
+        I confirm Copilot may start one child session and draft PR per selected repository.
+      </label>
+      <button id="copy">Copy request</button>
+      <button id="export">Export JSON</button>
+      <button class="primary" id="request" disabled>Request migration</button>
+    </footer>
+  </div>
+  <script>
+    "use strict";
+    const token = ${serializeForInlineScript(token)};
+    const ui = {
+      state: null,
+      activeRepository: null,
+      visible: [],
+    };
+    const byId = (id) => document.getElementById(id);
+    const status = byId("status");
+
+    function text(value) {
+      if (value === null || value === undefined || value === "") return "—";
+      if (Array.isArray(value)) return value.length ? value.join(", ") : "—";
+      if (typeof value === "object") {
+        const entries = Object.entries(value);
+        return entries.length ? entries.map(([key, item]) => key + ":" + item).join(", ") : "{}";
+      }
+      return String(value);
+    }
+
+    function setStatus(message, kind = "info") {
+      status.textContent = message;
+      status.dataset.kind = kind;
+    }
+
+    async function api(path, options = {}) {
+      const response = await fetch(path, {
+        ...options,
+        headers: {
+          "Content-Type": "application/json",
+          ...(options.method === "POST" ? { "X-Canvas-Token": token } : {}),
+          ...(options.headers || {}),
+        },
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        const error = new Error(payload.error?.message || "Canvas request failed.");
+        error.code = payload.error?.code;
+        throw error;
+      }
+      return payload;
+    }
+
+    function summaryMetric(label, value) {
+      const element = document.createElement("div");
+      element.className = "metric";
+      const strong = document.createElement("strong");
+      strong.textContent = String(value);
+      const caption = document.createElement("span");
+      caption.className = "muted";
+      caption.textContent = label;
+      element.append(strong, caption);
+      return element;
+    }
+
+    function renderSummary() {
+      const records = ui.state.records || [];
+      const analyses = records.map((record) => record.analysis);
+      const values = [
+        ["Workflows", records.length],
+        ["Compliant", analyses.filter((item) => item.compliant).length],
+        ["Migration needed", analyses.filter((item) => item.status === "migration-needed").length],
+        ["Incomplete", analyses.filter((item) => item.status === "incomplete").length],
+        ["Parse errors", analyses.filter((item) => item.status === "parse-error").length],
+        ["Selected", ui.state.selection.length],
+      ];
+      byId("summary").replaceChildren(...values.map(([label, value]) => summaryMetric(label, value)));
+    }
+
+    function codeCell(value) {
+      const cell = document.createElement("td");
+      const code = document.createElement("code");
+      code.textContent = text(value);
+      cell.append(code);
+      return cell;
+    }
+
+    function repositoryCell(record) {
+      const cell = document.createElement("td");
+      const link = document.createElement(record.repositoryUrl ? "a" : "span");
+      link.textContent = record.repository;
+      if (record.repositoryUrl) {
+        link.href = record.repositoryUrl;
+        link.target = "_blank";
+        link.rel = "noreferrer";
+      }
+      cell.append(link);
+      if (record.archived) {
+        const archived = document.createElement("div");
+        archived.className = "muted";
+        archived.textContent = "Archived";
+        cell.append(archived);
+      }
+      return cell;
+    }
+
+    function workflowCell(record) {
+      const cell = document.createElement("td");
+      const path = document.createElement(record.workflowUrl ? "a" : "span");
+      path.textContent = text(record.workflowPath);
+      if (record.workflowUrl) {
+        path.href = record.workflowUrl;
+        path.target = "_blank";
+        path.rel = "noreferrer";
+      }
+      const name = document.createElement("div");
+      name.className = "muted";
+      name.textContent = text(record.workflowName);
+      cell.append(path, name);
+      return cell;
+    }
+
+    function complianceCell(record) {
+      const cell = document.createElement("td");
+      const references = record.processJobs.map((job) => job.reference);
+      const reference = document.createElement("code");
+      reference.textContent = text(references);
+      const badge = document.createElement("span");
+      badge.className = "badge";
+      badge.dataset.status = record.analysis.status;
+      badge.textContent = record.analysis.status;
+      cell.append(reference, document.createElement("br"), badge);
+      return cell;
+    }
+
+    function triggerText(record) {
+      return [
+        "events=" + text(record.events),
+        "push=" + text(record.pushBranches),
+        "pull_request=" + text(record.pullRequestBranches),
+        "types=" + text(record.pullRequestTypes),
+        "schedule=" + text(record.schedules),
+      ].join("\\n");
+    }
+
+    function permissionText(record) {
+      return [
+        "workflow=" + text(record.permissions),
+        ...record.processJobs.map((job) => "job=" + text(job.permissions)),
+      ].join("\\n");
+    }
+
+    function jobValues(record, field) {
+      return record.processJobs.map((job) => job[field]);
+    }
+
+    function createRow(record) {
+      const row = document.createElement("tr");
+      row.dataset.repository = record.repository;
+      row.dataset.active = String(record.repository === ui.activeRepository);
+      row.addEventListener("click", (event) => {
+        if (event.target instanceof HTMLInputElement || event.target instanceof HTMLAnchorElement) return;
+        ui.activeRepository = record.repository;
+        renderRows();
+        renderInspector(record);
+      });
+      const selectCell = document.createElement("td");
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.checked = ui.state.selection.includes(record.repository);
+      checkbox.ariaLabel = "Select " + record.repository;
+      checkbox.addEventListener("change", async () => {
+        const next = new Set(ui.state.selection);
+        checkbox.checked ? next.add(record.repository) : next.delete(record.repository);
+        await updateSelection([...next]);
+      });
+      selectCell.append(checkbox);
+      row.append(
+        selectCell,
+        repositoryCell(record),
+        workflowCell(record),
+        complianceCell(record),
+        codeCell(triggerText(record)),
+        codeCell("group=" + text(record.concurrencyGroup) + "\\ncancel=" + text(record.cancelInProgress)),
+        codeCell(permissionText(record)),
+        codeCell(jobValues(record, "condition")),
+        codeCell(record.processJobs.map((job) => job.secretMode + ": " + text(job.secretMappings))),
+        codeCell(record.processJobs.map((job) => job.inputs)),
+        codeCell(record.additionalJobs),
+      );
+      return row;
+    }
+
+    function filteredRecords() {
+      const query = byId("search").value.trim().toLowerCase();
+      const filter = byId("filter").value;
+      return (ui.state.records || []).filter((record) => {
+        const matchesQuery = !query || [
+          record.repository,
+          record.workflowPath,
+          record.workflowName,
+          ...record.processJobs.map((job) => job.reference),
+        ].some((value) => String(value || "").toLowerCase().includes(query));
+        const matchesFilter = !filter || record.analysis.status === filter;
+        return matchesQuery && matchesFilter;
+      });
+    }
+
+    function renderRows() {
+      ui.visible = filteredRecords();
+      byId("rows").replaceChildren(...ui.visible.map(createRow));
+      byId("empty").hidden = ui.visible.length > 0;
+    }
+
+    function detailBlock(title, value, instruction) {
+      const block = document.createElement("div");
+      block.className = "delta";
+      const heading = document.createElement("h3");
+      heading.textContent = title;
+      const description = document.createElement("div");
+      description.textContent = instruction;
+      const pre = document.createElement("pre");
+      pre.textContent = text(value);
+      block.append(heading, description, pre);
+      return block;
+    }
+
+    function detailSection(title, entries, mapping) {
+      const section = document.createElement("section");
+      section.className = "detail-section";
+      const heading = document.createElement("h3");
+      heading.textContent = title;
+      section.append(heading);
+      if (!entries.length) {
+        const empty = document.createElement("p");
+        empty.className = "muted";
+        empty.textContent = "None.";
+        section.append(empty);
+      } else {
+        section.append(...entries.map(mapping));
+      }
+      return section;
+    }
+
+    function renderInspector(record) {
+      const inspector = byId("inspector");
+      const heading = document.createElement("h2");
+      heading.textContent = record.repository;
+      const statusBadge = document.createElement("span");
+      statusBadge.className = "badge";
+      statusBadge.dataset.status = record.analysis.status;
+      statusBadge.textContent = record.analysis.status;
+      const path = document.createElement("p");
+      path.className = "muted";
+      path.textContent = text(record.workflowPath);
+      const deltaSection = detailSection(
+        "Required changes",
+        record.analysis.deltas,
+        (delta) => detailBlock(delta.field, { current: delta.current, target: delta.target }, delta.instruction),
+      );
+      const preserveSection = detailSection(
+        "Preserve after verification",
+        record.analysis.preservation,
+        (item) => detailBlock(item.field, item.value, item.instruction),
+      );
+      const warningSection = detailSection(
+        "Manual boundary review",
+        record.analysis.reviewWarnings,
+        (item) => detailBlock(item.field, item.value, item.instruction),
+      );
+      const missingSection = detailSection(
+        "Missing inventory evidence",
+        record.analysis.missingFields,
+        (field) => detailBlock(field, "not captured", "Refresh with a compatible inventory script before requesting migration."),
+      );
+      inspector.replaceChildren(heading, statusBadge, path, deltaSection, preserveSection, warningSection, missingSection);
+    }
+
+    function renderState() {
+      renderSummary();
+      renderRows();
+      byId("request").disabled = !byId("confirm").checked || ui.state.selection.length === 0 || ui.state.inventoryStatus !== "ready";
+      if (ui.activeRepository) {
+        const active = ui.state.records.find((record) => record.repository === ui.activeRepository);
+        if (active) renderInspector(active);
+      }
+      if (ui.state.inventoryStatus === "failed") {
+        setStatus("Refresh failed: " + text(ui.state.error?.message), "error");
+      } else if (ui.state.inventoryStatus === "ready") {
+        setStatus(
+          "Inventory refreshed " + text(ui.state.generatedAt) + " from " + text(ui.state.organization) + ".",
+          "success",
+        );
+      } else if (ui.state.inventoryStatus === "refreshing") {
+        setStatus("Refreshing authenticated GitHub inventory…");
+      } else {
+        setStatus("No current inventory. Refresh to inspect the fleet.");
+      }
+    }
+
+    async function loadState() {
+      ui.state = await api("/api/state");
+      renderState();
+    }
+
+    async function updateSelection(repositories) {
+      try {
+        const result = await api("/api/selection", {
+          method: "POST",
+          body: JSON.stringify({ repositories }),
+        });
+        ui.state.selection = result.repositories;
+        renderState();
+      } catch (error) {
+        setStatus(error.message, "error");
+        renderRows();
+      }
+    }
+
+    async function previewRequest() {
+      return api("/api/migration", {
+        method: "POST",
+        body: JSON.stringify({
+          repositories: ui.state.selection,
+          dryRun: true,
+          confirmed: false,
+        }),
+      });
+    }
+
+    byId("refresh").addEventListener("click", async () => {
+      byId("refresh").disabled = true;
+      setStatus("Refreshing authenticated GitHub inventory…");
+      try {
+        await api("/api/refresh", {
+          method: "POST",
+          body: JSON.stringify({ organization: ui.state.organization || "PSModule" }),
+        });
+      } catch (error) {
+        setStatus(error.message, "error");
+      } finally {
+        await loadState();
+        byId("refresh").disabled = false;
+      }
+    });
+    byId("search").addEventListener("input", renderRows);
+    byId("filter").addEventListener("change", renderRows);
+    byId("select-visible").addEventListener("click", () => updateSelection(ui.visible.map((record) => record.repository)));
+    byId("clear-selection").addEventListener("click", () => updateSelection([]));
+    byId("confirm").addEventListener("change", renderState);
+    byId("copy").addEventListener("click", async () => {
+      try {
+        const preview = await previewRequest();
+        await navigator.clipboard.writeText(preview.prompt);
+        setStatus("Migration request copied to the clipboard.", "success");
+      } catch (error) {
+        setStatus(error.message, "error");
+      }
+    });
+    byId("export").addEventListener("click", async () => {
+      try {
+        const preview = await previewRequest();
+        const blob = new Blob([JSON.stringify(preview.request, null, 2) + "\\n"], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = "process-workflow-migration-request.json";
+        link.click();
+        URL.revokeObjectURL(url);
+        setStatus("Structured migration request exported.", "success");
+      } catch (error) {
+        setStatus(error.message, "error");
+      }
+    });
+    byId("request").addEventListener("click", async () => {
+      if (!byId("confirm").checked) {
+        setStatus("Confirm the repository-scoped child-session request first.", "error");
+        return;
+      }
+      const confirmed = window.confirm(
+        "Send this request to the active Copilot agent? It will orchestrate one child session, branch, and draft pull request per selected repository.",
+      );
+      if (!confirmed) return;
+      byId("request").disabled = true;
+      try {
+        const result = await api("/api/migration", {
+          method: "POST",
+          body: JSON.stringify({
+            repositories: ui.state.selection,
+            dryRun: false,
+            confirmed: true,
+          }),
+        });
+        setStatus("Migration request sent to the active agent as message " + result.messageId + ".", "success");
+      } catch (error) {
+        setStatus(error.message, "error");
+      } finally {
+        renderState();
+      }
+    });
+
+    loadState().catch((error) => setStatus(error.message, "error"));
+  </script>
+</body>
+</html>`;
+}

--- a/.github/extensions/process-workflow-fleet/renderer.mjs
+++ b/.github/extensions/process-workflow-fleet/renderer.mjs
@@ -280,9 +280,7 @@ export function renderDashboard(token) {
           <table aria-label="Process-PSModule caller workflow inventory">
             <thead>
               <tr>
-                <th scope="col">Select</th>
                 <th scope="col">Repository</th>
-                <th scope="col">Workflow</th>
                 <th scope="col">Reference / compliance</th>
                 <th scope="col">Triggers</th>
                 <th scope="col">Concurrency</th>
@@ -410,22 +408,6 @@ export function renderDashboard(token) {
       return cell;
     }
 
-    function workflowCell(record) {
-      const cell = document.createElement("td");
-      const path = document.createElement(record.workflowUrl ? "a" : "span");
-      path.textContent = text(record.workflowPath);
-      if (record.workflowUrl) {
-        path.href = record.workflowUrl;
-        path.target = "_blank";
-        path.rel = "noreferrer";
-      }
-      const name = document.createElement("div");
-      name.className = "muted";
-      name.textContent = text(record.workflowName);
-      cell.append(path, name);
-      return cell;
-    }
-
     function complianceCell(record) {
       const cell = document.createElement("td");
       const references = record.processJobs.map((job) => job.reference);
@@ -470,7 +452,6 @@ export function renderDashboard(token) {
         renderRows();
         renderInspector(record);
       });
-      const selectCell = document.createElement("td");
       const checkbox = document.createElement("input");
       checkbox.type = "checkbox";
       checkbox.checked = ui.state.selection.includes(record.repository);
@@ -480,11 +461,10 @@ export function renderDashboard(token) {
         checkbox.checked ? next.add(record.repository) : next.delete(record.repository);
         await updateSelection([...next]);
       });
-      selectCell.append(checkbox);
+      const identityCell = repositoryCell(record);
+      identityCell.prepend(checkbox, document.createTextNode(" "));
       row.append(
-        selectCell,
-        repositoryCell(record),
-        workflowCell(record),
+        identityCell,
         complianceCell(record),
         codeCell(triggerText(record)),
         codeCell("group=" + text(record.concurrencyGroup) + "\\ncancel=" + text(record.cancelInProgress)),
@@ -558,7 +538,16 @@ export function renderDashboard(token) {
       statusBadge.textContent = record.analysis.status;
       const path = document.createElement("p");
       path.className = "muted";
-      path.textContent = text(record.workflowPath);
+      if (record.workflowUrl) {
+        const link = document.createElement("a");
+        link.href = record.workflowUrl;
+        link.target = "_blank";
+        link.rel = "noreferrer";
+        link.textContent = text(record.workflowPath);
+        path.append(link, document.createTextNode(" · " + text(record.workflowName)));
+      } else {
+        path.textContent = text(record.workflowPath) + " · " + text(record.workflowName);
+      }
       const deltaSection = detailSection(
         "Required changes",
         record.analysis.deltas,
@@ -604,9 +593,36 @@ export function renderDashboard(token) {
       }
     }
 
+    function shouldAutoRefresh() {
+      if (ui.state.inventoryStatus === "not-refreshed") return true;
+      if (ui.state.inventoryStatus !== "ready" || !ui.state.generatedAt) return false;
+      const generatedAt = Date.parse(ui.state.generatedAt);
+      return Number.isFinite(generatedAt) && Date.now() - generatedAt > 15 * 60 * 1000;
+    }
+
+    async function refreshInventory() {
+      byId("refresh").disabled = true;
+      setStatus("Refreshing authenticated GitHub inventory…");
+      try {
+        await api("/api/refresh", {
+          method: "POST",
+          body: JSON.stringify({ organization: ui.state.organization || "PSModule" }),
+        });
+      } catch (error) {
+        setStatus(error.message, "error");
+      } finally {
+        ui.state = await api("/api/state");
+        renderState();
+        byId("refresh").disabled = false;
+      }
+    }
+
     async function loadState() {
       ui.state = await api("/api/state");
       renderState();
+      if (shouldAutoRefresh()) {
+        await refreshInventory();
+      }
     }
 
     async function updateSelection(repositories) {
@@ -634,21 +650,7 @@ export function renderDashboard(token) {
       });
     }
 
-    byId("refresh").addEventListener("click", async () => {
-      byId("refresh").disabled = true;
-      setStatus("Refreshing authenticated GitHub inventory…");
-      try {
-        await api("/api/refresh", {
-          method: "POST",
-          body: JSON.stringify({ organization: ui.state.organization || "PSModule" }),
-        });
-      } catch (error) {
-        setStatus(error.message, "error");
-      } finally {
-        await loadState();
-        byId("refresh").disabled = false;
-      }
-    });
+    byId("refresh").addEventListener("click", refreshInventory);
     byId("search").addEventListener("input", renderRows);
     byId("filter").addEventListener("change", renderRows);
     byId("select-visible").addEventListener("click", () => updateSelection(ui.visible.map((record) => record.repository)));

--- a/.github/scripts/Get-ProcessPSModuleWorkflowInventory.ps1
+++ b/.github/scripts/Get-ProcessPSModuleWorkflowInventory.ps1
@@ -590,6 +590,7 @@ function Get-WorkflowInventoryItem {
             } else {
                 [ordered]@{}
             }
+            Permissions    = ConvertTo-PermissionValue -Value (Get-MapValue -Map $job -Name 'permissions')
             Environment    = Get-MapValue -Map $job -Name 'environment'
             Condition      = Get-MapValue -Map $job -Name 'if'
         }
@@ -677,6 +678,8 @@ function Get-WorkflowInventoryItem {
         PushPathsIgnore     = ConvertTo-StringArray -Value (Get-MapValue -Map $push -Name 'paths-ignore')
         PullRequestBranches = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'branches')
         PullRequestTypes    = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'types')
+        PullRequestPaths    = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'paths')
+        PullRequestPathsIgnore = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'paths-ignore')
         ConcurrencyGroup    = $concurrencyGroup
         CancelInProgress    = $cancelInProgress
         Permissions         = $permissions

--- a/.github/scripts/Get-ProcessPSModuleWorkflowInventory.ps1
+++ b/.github/scripts/Get-ProcessPSModuleWorkflowInventory.ps1
@@ -659,35 +659,35 @@ function Get-WorkflowInventoryItem {
     )
 
     [pscustomobject]@{
-        Repository          = $WorkflowFile.Repository
-        DefaultBranch       = $WorkflowFile.DefaultBranch
-        Archived            = $WorkflowFile.Archived
-        RepositoryUrl       = $WorkflowFile.RepositoryUrl
-        WorkflowPath        = $WorkflowFile.WorkflowPath
-        WorkflowUrl         = $WorkflowFile.WorkflowUrl
-        SearchQuery         = $WorkflowFile.SearchQuery
-        Status              = 'Parsed'
-        Error               = $null
-        WorkflowName        = Get-MapValue -Map $workflow -Name 'name'
-        RunName             = Get-MapValue -Map $workflow -Name 'run-name'
-        Events              = @(Get-MapKey -Map $trigger | Sort-Object)
-        Schedules           = @($schedule | ForEach-Object { Get-MapValue -Map $_ -Name 'cron' })
-        PushBranches        = ConvertTo-StringArray -Value (Get-MapValue -Map $push -Name 'branches')
-        PushBranchesIgnore  = ConvertTo-StringArray -Value (Get-MapValue -Map $push -Name 'branches-ignore')
-        PushPaths           = ConvertTo-StringArray -Value (Get-MapValue -Map $push -Name 'paths')
-        PushPathsIgnore     = ConvertTo-StringArray -Value (Get-MapValue -Map $push -Name 'paths-ignore')
-        PullRequestBranches = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'branches')
-        PullRequestTypes    = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'types')
-        PullRequestPaths    = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'paths')
+        Repository             = $WorkflowFile.Repository
+        DefaultBranch          = $WorkflowFile.DefaultBranch
+        Archived               = $WorkflowFile.Archived
+        RepositoryUrl          = $WorkflowFile.RepositoryUrl
+        WorkflowPath           = $WorkflowFile.WorkflowPath
+        WorkflowUrl            = $WorkflowFile.WorkflowUrl
+        SearchQuery            = $WorkflowFile.SearchQuery
+        Status                 = 'Parsed'
+        Error                  = $null
+        WorkflowName           = Get-MapValue -Map $workflow -Name 'name'
+        RunName                = Get-MapValue -Map $workflow -Name 'run-name'
+        Events                 = @(Get-MapKey -Map $trigger | Sort-Object)
+        Schedules              = @($schedule | ForEach-Object { Get-MapValue -Map $_ -Name 'cron' })
+        PushBranches           = ConvertTo-StringArray -Value (Get-MapValue -Map $push -Name 'branches')
+        PushBranchesIgnore     = ConvertTo-StringArray -Value (Get-MapValue -Map $push -Name 'branches-ignore')
+        PushPaths              = ConvertTo-StringArray -Value (Get-MapValue -Map $push -Name 'paths')
+        PushPathsIgnore        = ConvertTo-StringArray -Value (Get-MapValue -Map $push -Name 'paths-ignore')
+        PullRequestBranches    = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'branches')
+        PullRequestTypes       = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'types')
+        PullRequestPaths       = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'paths')
         PullRequestPathsIgnore = ConvertTo-StringArray -Value (Get-MapValue -Map $pullRequest -Name 'paths-ignore')
-        ConcurrencyGroup    = $concurrencyGroup
-        CancelInProgress    = $cancelInProgress
-        Permissions         = $permissions
-        ProcessJobs         = @($processJobs)
-        AdditionalJobs      = @($allJobNames | Where-Object { $_ -notin $processJobNames })
-        VersionComments     = $versionComments
-        TargetReference     = $ExpectedTargetReference
-        MatchesTarget       = if ($ExpectedTargetReference) {
+        ConcurrencyGroup       = $concurrencyGroup
+        CancelInProgress       = $cancelInProgress
+        Permissions            = $permissions
+        ProcessJobs            = @($processJobs)
+        AdditionalJobs         = @($allJobNames | Where-Object { $_ -notin $processJobNames })
+        VersionComments        = $versionComments
+        TargetReference        = $ExpectedTargetReference
+        MatchesTarget          = if ($ExpectedTargetReference) {
             @($processJobs | Where-Object { -not $_.MatchesTarget }).Count -eq 0
         } else {
             $null

--- a/.github/scripts/tests/Get-ProcessPSModuleWorkflowInventory.Tests.ps1
+++ b/.github/scripts/tests/Get-ProcessPSModuleWorkflowInventory.Tests.ps1
@@ -40,6 +40,10 @@ permissions:
 jobs:
   Process-PSModule:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
     with:
       Debug: true
@@ -95,12 +99,17 @@ Describe 'Get-ProcessPSModuleWorkflowInventory' {
         $result[0].Events | Should -Be @('pull_request', 'push', 'schedule', 'workflow_dispatch')
         $result[0].PushBranches | Should -Be @('main')
         $result[0].PullRequestTypes | Should -Be @('opened', 'synchronize')
+        $result[0].PullRequestPaths | Should -BeNullOrEmpty
+        $result[0].PullRequestPathsIgnore | Should -BeNullOrEmpty
         $result[0].ConcurrencyGroup | Should -Be '${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
         $result[0].CancelInProgress | Should -BeFalse
         $result[0].ProcessJobs[0].Reference | Should -Be 'v8'
         $result[0].ProcessJobs[0].MatchesTarget | Should -BeTrue
         $result[0].MatchesTarget | Should -BeTrue
         $result[0].ProcessJobs[0].Condition | Should -Match 'head.repo.full_name'
+        $result[0].ProcessJobs[0].Permissions.contents | Should -Be 'read'
+        $result[0].ProcessJobs[0].Permissions.pages | Should -Be 'write'
+        $result[0].ProcessJobs[0].Permissions.'id-token' | Should -Be 'write'
         $result[0].ProcessJobs[0].Inputs.Keys | Should -Contain 'Debug'
         $result[0].ProcessJobs[0].SecretMappings.Keys | Should -Be @(
             'PSGALLERY_API_KEY'


### PR DESCRIPTION
Maintainers can inspect the Process-PSModule caller fleet and prepare safe v8 migration requests from a project-scoped Copilot canvas.

## New: Workflow fleet inspection

The canvas will summarize caller workflows, compare each repository with the agreed v8 contract, and route confirmed migration requests through the active Copilot agent without mutating repositories from the canvas HTTP server.

---
<details>
<summary>Technical details</summary>

- The project extension is scaffolded under `.github/extensions/process-workflow-fleet/` and will use the existing inventory script from the stacked base branch.
- This draft is opened early so implementation and validation remain visible.

</details>

<details>
<summary>Relevant issues (or links)</summary>

### Related work

- Depends on PSModule/Process-PSModule#515
- Followed by PSModule/Process-PSModule#438

</details>