### PR TITLE
🪲 [Fix]: Obsolete GitHub token write permissions removed

### DIFF
--- a/.github/workflows/Build-Docs.yml
+++ b/.github/workflows/Build-Docs.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read # to checkout the repo
-  statuses: write # to create commit status
 
 jobs:
   Build-Docs:

--- a/.github/workflows/Lint-Repository.yml
+++ b/.github/workflows/Lint-Repository.yml
@@ -9,9 +9,7 @@ on:
         required: true
 
 permissions:
-  contents: read       # to checkout the repository
-  statuses: write      # to update the status of the workflow from linter
-  pull-requests: write # to post super-linter summary comments on PRs
+  contents: read # to checkout the repository
 
 jobs:
   Lint-Repository:

--- a/.github/workflows/Plan.yml
+++ b/.github/workflows/Plan.yml
@@ -64,7 +64,6 @@ on:
 
 permissions:
   contents: read # to checkout the repo
-  pull-requests: write # to add labels / comments to PRs
 
 jobs:
   Plan:

--- a/.github/workflows/Publish-Module.yml
+++ b/.github/workflows/Publish-Module.yml
@@ -25,8 +25,7 @@ jobs:
     name: Publish-Module
     runs-on: ubuntu-24.04
     permissions:
-      contents: write # Create releases and upload release artifacts.
-      pull-requests: write # Comment on pull requests.
+      contents: read # Checkout uses github.token.
     env:
       SETTINGS: ${{ inputs.Settings }}
     steps:

--- a/.github/workflows/Workflow-Test-Default.yml
+++ b/.github/workflows/Workflow-Test-Default.yml
@@ -35,9 +35,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
+  contents: read
   pages: write
   id-token: write
 

--- a/.github/workflows/Workflow-Test-WithManifest.yml
+++ b/.github/workflows/Workflow-Test-WithManifest.yml
@@ -35,9 +35,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
+  contents: read
   pages: write
   id-token: write
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -69,9 +69,7 @@ on:
           ^README\.md$
 
 permissions:
-  contents: write # to checkout the repo and create releases on the repo
-  pull-requests: write # to write comments to PRs
-  statuses: write # to update the status of the workflow from linter
+  contents: read # to checkout the repo
   pages: write # to deploy to Pages
   id-token: write # to verify the deployment originates from an appropriate source
 

--- a/docs/content/get-started/repository-setup.md
+++ b/docs/content/get-started/repository-setup.md
@@ -57,22 +57,20 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
+  contents: read
   pages: write
   id-token: write
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
     secrets:
       PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
       GitHubAppClientId: ${{ secrets.SHELLY_CLIENT_ID }}
       GitHubAppPrivateKey: ${{ secrets.SHELLY_PRIVATE_KEY }}
 ```
 
-Every permission in that block is required. A push to `main` publishes a stable release after the full pipeline passes;
+Every permission in that block is required. GitHub App installation tokens perform repository writes. A push to `main` publishes a stable release after the full pipeline passes;
 the pull-request trigger handles CI, prereleases, and prerelease cleanup. See
 [Workflow inputs](../reference/workflow-inputs.md) for what each permission is used for, and
 [Calling the workflow](../guides/calling-the-workflow.md) for passing test secrets and variables.

--- a/docs/content/guides/calling-the-workflow.md
+++ b/docs/content/guides/calling-the-workflow.md
@@ -40,15 +40,13 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
+  contents: read
   pages: write
   id-token: write
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
     secrets:
       PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
       GitHubAppClientId: ${{ secrets.SHELLY_CLIENT_ID }}
@@ -94,7 +92,7 @@ changes:
 ```yaml
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
     secrets:
       PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
       GitHubAppClientId: ${{ secrets.SHELLY_CLIENT_ID }}
@@ -123,7 +121,7 @@ content lines stay at the same indentation level:
 ```yaml
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
     secrets:
       PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
       GitHubAppClientId: ${{ secrets.SHELLY_CLIENT_ID }}
@@ -235,7 +233,7 @@ You can also pass patterns via the workflow input:
 ```yaml
 jobs:
   Process:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
     with:
       ImportantFilePatterns: |
         ^src/
@@ -248,7 +246,7 @@ To disable triggering via the workflow input, pass an explicit empty string:
 ```yaml
 jobs:
   process:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
     with:
       ImportantFilePatterns: ''
 ```

--- a/docs/content/guides/github-app-authentication.md
+++ b/docs/content/guides/github-app-authentication.md
@@ -23,7 +23,7 @@ names. Map the caller's secrets explicitly:
 ```yaml
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v8
     secrets:
       PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
       GitHubAppClientId: ${{ secrets.SHELLY_CLIENT_ID }}

--- a/docs/content/reference/workflow-inputs.md
+++ b/docs/content/reference/workflow-inputs.md
@@ -37,14 +37,12 @@ See [passing test data](../guides/calling-the-workflow.md#passing-test-data) for
 
 ## Workflow `github.token` permissions
 
-The following permissions are needed by the caller workflow's default `github.token` for operations that do not use
-Shelly, such as linting and GitHub Pages deployment:
+The following permissions are needed by the caller workflow's default `github.token` for checkout and GitHub Pages
+deployment:
 
 ```yaml
 permissions:
-  contents: write      # to checkout the repo and create releases on the repo
-  pull-requests: write # to write comments to PRs
-  statuses: write      # to update the status of the workflow from linter
+  contents: read       # to checkout the repo
   pages: write         # to deploy to Pages
   id-token: write      # to verify the Pages deployment originates from an appropriate source
 ```


### PR DESCRIPTION
Repositories that use the GitHub App permission model can run Process-PSModule without granting unneeded repository, pull-request, or status write access. GitHub Pages deployments continue to use the caller's `github.token` with `contents: read`, `pages: write`, and `id-token: write`.

## Fixed: Reusable workflow permission escalation

The reusable workflow no longer requests permissions that GitHub App installation tokens already provide for release and pull-request operations. Update caller workflows to use the narrowed permission block documented for `v8`.

```yaml
permissions:
  contents: read
  pages: write
  id-token: write
```

---
<details>
<summary>Technical details</summary>

- Removed legacy `github.token` write requests from the reusable workflow and nested jobs; scoped GitHub App tokens retain repository and pull-request write access.
- Updated repository workflow tests and caller documentation to use the `v8` permission contract.

| Changed surface | Standards checked | Framework docs checked | Result |
| --- | --- | --- | --- |
| `.github/workflows/**` | GitHub Actions | Reusable workflow contract | Fixed in this PR |
| `docs/content/**` | Markdown, Natural Language | Workflow setup guides | Fixed in this PR |

</details>

<details>
<summary>Relevant issues (or links)</summary>

### Related work

- References PSModule/Process-PSModule#510

</details>