### PR TITLE
fix: Skip docs verification for closed pull requests

### DIFF
--- a/.github/workflows/Workflow-Test-Default.yml
+++ b/.github/workflows/Workflow-Test-Default.yml
@@ -64,6 +64,7 @@ jobs:
         ^\.github/workflows/(?!Release\.yml$|Linter\.yml$)
 
   VerifyRootFunctionsIndexDefault:
+    if: github.event.action != 'closed'
     name: Verify root Functions index [Default]
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/Workflow-Test-WithManifest.yml
+++ b/.github/workflows/Workflow-Test-WithManifest.yml
@@ -64,6 +64,7 @@ jobs:
         ^\.github/workflows/(?!Release\.yml$|Linter\.yml$)
 
   VerifyRootFunctionsIndexWithManifest:
+    if: github.event.action != 'closed'
     name: Verify root Functions index [WithManifest]
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Summary
- Skip root Functions index artifact verification for closed pull-request runs.
- Preserve verification for active pull requests, pushes, schedules, and manual runs.

## Root cause
Closed pull-request events intentionally skip Build-Docs, so no docs artifact exists for the unconditional verifier to download.