### PR TITLE
🪲 [Fix]: Manual dispatch on the default branch honours the merged pull request's version label

### DIFF
--- a/.github/actions/Get-PSModuleSettings/src/Get-PSModuleSettings.Helpers.psm1
+++ b/.github/actions/Get-PSModuleSettings/src/Get-PSModuleSettings.Helpers.psm1
@@ -109,6 +109,103 @@ function Select-PullRequestForPush {
         Select-Object -First 1
 }
 
+function Test-ShouldResolveAssociatedPullRequest {
+    <#
+        .SYNOPSIS
+        Decides whether a commit's associated pull request must be resolved from the GitHub API.
+
+        .DESCRIPTION
+        A push to any branch resolves its associated pull request so a default-branch release
+        honours the merged pull request's version label. A manual dispatch on the default branch is
+        the documented recovery route for a failed or cancelled release run and targets the same
+        merge commit, so it must resolve the same pull request. Excluding it left the pull request
+        null and silently downgraded a labelled Major or Minor release to a Patch bump.
+
+        .OUTPUTS
+        Boolean. True when the association lookup must run.
+
+        .EXAMPLE
+        Test-ShouldResolveAssociatedPullRequest -IsPush $false -IsManualDispatchToDefaultBranch $true -CommitSha 'abc123'
+
+        Returns $true, because a default-branch dispatch releases the same commit a push would.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        # Whether the workflow was triggered by a push event.
+        [Parameter()]
+        [bool] $IsPush,
+
+        # Whether the workflow was manually dispatched against the default branch.
+        [Parameter()]
+        [bool] $IsManualDispatchToDefaultBranch,
+
+        # The commit the workflow is resolving a release for.
+        [Parameter()]
+        [string] $CommitSha
+    )
+
+    ($IsPush -or $IsManualDispatchToDefaultBranch) -and -not [string]::IsNullOrWhiteSpace($CommitSha)
+}
+
+function Get-DiscardedReleasePullRequest {
+    <#
+        .SYNOPSIS
+        Reports merged default-branch pull requests whose version label would be discarded.
+
+        .DESCRIPTION
+        Select-PullRequestForPush returns nothing both when a commit has no associated pull request
+        and when every associated pull request fails its criteria. Only the first case is safe: a
+        commit pushed directly to the default branch has no label to honour, so the direct-release
+        path applies the default patch bump.
+
+        The unsafe case is a pull request that was merged into the default branch, and therefore
+        carries the version label that was meant to drive the release, but was not selected because
+        its merge commit does not match the commit being released. Falling back to a patch bump
+        there publishes a version nobody asked for, and a PowerShell Gallery version cannot be
+        reclaimed, so the caller must fail instead.
+
+        Pull requests that are not merged are ignored. The GitHub commit association endpoint also
+        returns open pull requests whose branch contains the commit, which is expected and carries
+        no release intent.
+
+        .OUTPUTS
+        String, one description per merged pull request that was rejected. Nothing when the
+        associated pull requests carry no release intent.
+
+        .EXAMPLE
+        Get-DiscardedReleasePullRequest -PullRequest $associated -DefaultBranch main -CommitSha $sha
+
+        Returns '#412 was merged into [main] with merge commit [abc123]'.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        # The pull requests the GitHub API associated with the commit.
+        [Parameter()]
+        [object[]] $PullRequest,
+
+        # The repository default branch a release must target.
+        [Parameter(Mandatory)]
+        [string] $DefaultBranch,
+
+        # The commit the workflow is resolving a release for.
+        [Parameter(Mandatory)]
+        [string] $CommitSha
+    )
+
+    foreach ($candidate in ($PullRequest | Where-Object { $null -ne $_ })) {
+        $isMergedToDefaultBranch = (
+            $candidate.Base.Ref -eq $DefaultBranch -and
+            -not [string]::IsNullOrWhiteSpace($candidate.merged_at)
+        )
+        if (-not $isMergedToDefaultBranch) { continue }
+        if ($candidate.merge_commit_sha -eq $CommitSha) { continue }
+
+        "#$($candidate.Number) was merged into [$DefaultBranch] with merge commit [$($candidate.merge_commit_sha)]"
+    }
+}
+
 function Get-FilesFromGitTree {
     <#
         .SYNOPSIS

--- a/.github/actions/Get-PSModuleSettings/src/Get-PSModuleSettings.Helpers.psm1
+++ b/.github/actions/Get-PSModuleSettings/src/Get-PSModuleSettings.Helpers.psm1
@@ -109,45 +109,6 @@ function Select-PullRequestForPush {
         Select-Object -First 1
 }
 
-function Test-ShouldResolveAssociatedPullRequest {
-    <#
-        .SYNOPSIS
-        Decides whether a commit's associated pull request must be resolved from the GitHub API.
-
-        .DESCRIPTION
-        A push to any branch resolves its associated pull request so a default-branch release
-        honours the merged pull request's version label. A manual dispatch on the default branch is
-        the documented recovery route for a failed or cancelled release run and targets the same
-        merge commit, so it must resolve the same pull request. Excluding it left the pull request
-        null and silently downgraded a labelled Major or Minor release to a Patch bump.
-
-        .OUTPUTS
-        Boolean. True when the association lookup must run.
-
-        .EXAMPLE
-        Test-ShouldResolveAssociatedPullRequest -IsPush $false -IsManualDispatchToDefaultBranch $true -CommitSha 'abc123'
-
-        Returns $true, because a default-branch dispatch releases the same commit a push would.
-    #>
-    [CmdletBinding()]
-    [OutputType([bool])]
-    param(
-        # Whether the workflow was triggered by a push event.
-        [Parameter()]
-        [bool] $IsPush,
-
-        # Whether the workflow was manually dispatched against the default branch.
-        [Parameter()]
-        [bool] $IsManualDispatchToDefaultBranch,
-
-        # The commit the workflow is resolving a release for.
-        [Parameter()]
-        [string] $CommitSha
-    )
-
-    ($IsPush -or $IsManualDispatchToDefaultBranch) -and -not [string]::IsNullOrWhiteSpace($CommitSha)
-}
-
 function Get-DiscardedReleasePullRequest {
     <#
         .SYNOPSIS
@@ -203,6 +164,112 @@ function Get-DiscardedReleasePullRequest {
         if ($candidate.merge_commit_sha -eq $CommitSha) { continue }
 
         "#$($candidate.Number) was merged into [$DefaultBranch] with merge commit [$($candidate.merge_commit_sha)]"
+    }
+}
+
+function Resolve-ReleasePullRequest {
+    <#
+        .SYNOPSIS
+        Resolves the pull request whose version label drives the release for a commit.
+
+        .DESCRIPTION
+        A push resolves the pull request associated with the pushed commit so a default-branch
+        release honours the merged pull request's version label. A manual dispatch on the default
+        branch is the documented recovery route for a failed or cancelled release run and targets
+        the same merge commit, so it must resolve the same pull request. Excluding it left the pull
+        request unresolved, and the version silently fell back to a patch bump through AutoPatching.
+
+        When no pull request is selected, the outcome depends on why. A commit pushed directly to
+        the default branch has no label to honour, so the release proceeds with the default patch
+        bump. A commit associated with a merged default-branch pull request that does not match it
+        does carry a label, and applying a patch bump would publish a version nobody asked for. A
+        PowerShell Gallery version cannot be reclaimed, so that case throws instead.
+
+        .OUTPUTS
+        PSCustomObject with Resolved, indicating whether the lookup ran, and PullRequest, which is
+        null when the commit has no associated release pull request.
+
+        .EXAMPLE
+        Resolve-ReleasePullRequest -EventName workflow_dispatch -CommitSha $sha -DefaultBranch main `
+            -IsManualDispatchToDefaultBranch $true -GetAssociatedPullRequest { param($Sha) $pulls }
+
+        Resolves the merged pull request for a recovery dispatch so its version label is honoured.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '',
+        Justification = 'Parameters are used inside a LogGroup script block.')]
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        # The name of the GitHub event that triggered the workflow.
+        [Parameter(Mandatory)]
+        [string] $EventName,
+
+        # The commit the workflow is resolving a release for.
+        [Parameter()]
+        [AllowEmptyString()]
+        [AllowNull()]
+        [string] $CommitSha,
+
+        # The repository default branch a release must target.
+        [Parameter(Mandatory)]
+        [string] $DefaultBranch,
+
+        # Whether the workflow was triggered by a push to the default branch.
+        [Parameter()]
+        [bool] $IsPushToDefaultBranch,
+
+        # Whether the workflow was manually dispatched against the default branch.
+        [Parameter()]
+        [bool] $IsManualDispatchToDefaultBranch,
+
+        # Returns the pull requests GitHub associates with a commit. Takes the commit SHA.
+        [Parameter(Mandatory)]
+        [scriptblock] $GetAssociatedPullRequest
+    )
+
+    $isPush = $EventName -eq 'push'
+    $shouldResolve = (
+        ($isPush -or $IsManualDispatchToDefaultBranch) -and
+        -not [string]::IsNullOrWhiteSpace($CommitSha)
+    )
+    if (-not $shouldResolve) {
+        return [pscustomobject]@{ Resolved = $false; PullRequest = $null }
+    }
+
+    LogGroup "Resolve pull request for commit [$CommitSha]" {
+        $associated = @((& $GetAssociatedPullRequest $CommitSha) | Where-Object { $null -ne $_ })
+        $pullRequest = Select-PullRequestForPush -PullRequest $associated `
+            -DefaultBranch $DefaultBranch `
+            -CommitSha $CommitSha
+
+        if ($pullRequest) {
+            Write-Host "Resolved pull request #$($pullRequest.Number) from commit [$CommitSha]."
+            return [pscustomobject]@{ Resolved = $true; PullRequest = $pullRequest }
+        }
+
+        # Only a release-bearing event can publish a wrong version. A push to a feature branch has
+        # no release to get wrong, and its commit is legitimately claimed by an open pull request.
+        $isReleaseEvent = $IsPushToDefaultBranch -or $IsManualDispatchToDefaultBranch
+        $discarded = if ($isReleaseEvent) {
+            @(Get-DiscardedReleasePullRequest -PullRequest $associated `
+                    -DefaultBranch $DefaultBranch `
+                    -CommitSha $CommitSha)
+        } else {
+            @()
+        }
+        if ($discarded.Count -gt 0) {
+            throw (
+                "Commit [$CommitSha] cannot be released because its version label cannot be determined. " +
+                'The following merged pull request(s) are associated with it but none matches the commit ' +
+                "being released: $($discarded -join '; '). " +
+                'Refusing to fall back to a patch bump, because a wrong version published to the ' +
+                'PowerShell Gallery cannot be reclaimed. Re-run the workflow against the merge commit ' +
+                'of the pull request you intend to release.'
+            )
+        }
+
+        Write-Host "::notice::No pull request is associated with commit [$CommitSha]."
+        [pscustomobject]@{ Resolved = $true; PullRequest = $null }
     }
 }
 

--- a/.github/actions/Get-PSModuleSettings/src/main.ps1
+++ b/.github/actions/Get-PSModuleSettings/src/main.ps1
@@ -242,12 +242,20 @@ LogGroup 'Calculate Job Run Conditions:' {
     $isManualDispatchToDefaultBranch = $isManualDispatch -and $workflowRef -eq $defaultBranch
     $pullRequest = $eventData.PullRequest
 
-    if ($isPush -and $commitSha) {
+    # A manual dispatch on the default branch is the documented recovery route for a failed or
+    # cancelled release run. It targets the same merge commit as the push it replaces, so it must
+    # resolve the same pull request and honour the same version label. Gating this lookup on
+    # $isPush alone left $pullRequest null for a dispatch, which silently downgraded a labelled
+    # Major or Minor release to a Patch bump through the AutoPatching fallback.
+    $shouldResolvePullRequest = Test-ShouldResolveAssociatedPullRequest -IsPush $isPush `
+        -IsManualDispatchToDefaultBranch $isManualDispatchToDefaultBranch `
+        -CommitSha $commitSha
+    if ($shouldResolvePullRequest) {
         LogGroup "Resolve pull request for commit [$commitSha]" {
             $owner = $env:GITHUB_REPOSITORY_OWNER
             $repo = $env:GITHUB_REPOSITORY_NAME
             $response = Invoke-GitHubAPI -ApiEndpoint "/repos/$owner/$repo/commits/$commitSha/pulls" -Method GET
-            $associatedPullRequests = @($response.Response)
+            $associatedPullRequests = @($response.Response | Where-Object { $null -ne $_ })
             $pullRequest = Select-PullRequestForPush -PullRequest $associatedPullRequests `
                 -DefaultBranch $defaultBranch `
                 -CommitSha $commitSha
@@ -255,6 +263,31 @@ LogGroup 'Calculate Job Run Conditions:' {
             if ($pullRequest) {
                 Write-Host "Resolved pull request #$($pullRequest.Number) from commit [$commitSha]."
             } else {
+                # Distinguish 'no pull request carries release intent' from 'a merged default-branch
+                # pull request exists but was not selected'. The first is a legitimate direct push to
+                # the default branch, which the direct-release path handles with the default patch
+                # bump. The second means the commit carries a version label that would be discarded,
+                # and a wrong version published to the PowerShell Gallery cannot be reclaimed, so
+                # fail loudly instead. Only release-bearing events are checked; a push to a feature
+                # branch has no release to get wrong.
+                $isReleaseEvent = $isPushToDefaultBranch -or $isManualDispatchToDefaultBranch
+                $discardedPullRequests = if ($isReleaseEvent) {
+                    @(Get-DiscardedReleasePullRequest -PullRequest $associatedPullRequests `
+                            -DefaultBranch $defaultBranch `
+                            -CommitSha $commitSha)
+                } else {
+                    @()
+                }
+                if ($discardedPullRequests.Count -gt 0) {
+                    throw (
+                        "Commit [$commitSha] cannot be released because its version label cannot be determined. " +
+                        'The following merged pull request(s) are associated with it but none matches the commit ' +
+                        "being released: $($discardedPullRequests -join '; '). " +
+                        'Refusing to fall back to a patch bump, because a wrong version published to the ' +
+                        'PowerShell Gallery cannot be reclaimed. Re-run the workflow against the merge commit ' +
+                        'of the pull request you intend to release.'
+                    )
+                }
                 Write-Host "::notice::No pull request is associated with commit [$commitSha]."
             }
         }

--- a/.github/actions/Get-PSModuleSettings/src/main.ps1
+++ b/.github/actions/Get-PSModuleSettings/src/main.ps1
@@ -247,50 +247,23 @@ LogGroup 'Calculate Job Run Conditions:' {
     # resolve the same pull request and honour the same version label. Gating this lookup on
     # $isPush alone left $pullRequest null for a dispatch, which silently downgraded a labelled
     # Major or Minor release to a Patch bump through the AutoPatching fallback.
-    $shouldResolvePullRequest = Test-ShouldResolveAssociatedPullRequest -IsPush $isPush `
-        -IsManualDispatchToDefaultBranch $isManualDispatchToDefaultBranch `
-        -CommitSha $commitSha
-    if ($shouldResolvePullRequest) {
-        LogGroup "Resolve pull request for commit [$commitSha]" {
+    $resolveParams = @{
+        EventName                       = $eventName
+        CommitSha                       = $commitSha
+        DefaultBranch                   = $defaultBranch
+        IsPushToDefaultBranch           = $isPushToDefaultBranch
+        IsManualDispatchToDefaultBranch = $isManualDispatchToDefaultBranch
+        GetAssociatedPullRequest        = {
+            param($Sha)
             $owner = $env:GITHUB_REPOSITORY_OWNER
             $repo = $env:GITHUB_REPOSITORY_NAME
-            $response = Invoke-GitHubAPI -ApiEndpoint "/repos/$owner/$repo/commits/$commitSha/pulls" -Method GET
-            $associatedPullRequests = @($response.Response | Where-Object { $null -ne $_ })
-            $pullRequest = Select-PullRequestForPush -PullRequest $associatedPullRequests `
-                -DefaultBranch $defaultBranch `
-                -CommitSha $commitSha
-
-            if ($pullRequest) {
-                Write-Host "Resolved pull request #$($pullRequest.Number) from commit [$commitSha]."
-            } else {
-                # Distinguish 'no pull request carries release intent' from 'a merged default-branch
-                # pull request exists but was not selected'. The first is a legitimate direct push to
-                # the default branch, which the direct-release path handles with the default patch
-                # bump. The second means the commit carries a version label that would be discarded,
-                # and a wrong version published to the PowerShell Gallery cannot be reclaimed, so
-                # fail loudly instead. Only release-bearing events are checked; a push to a feature
-                # branch has no release to get wrong.
-                $isReleaseEvent = $isPushToDefaultBranch -or $isManualDispatchToDefaultBranch
-                $discardedPullRequests = if ($isReleaseEvent) {
-                    @(Get-DiscardedReleasePullRequest -PullRequest $associatedPullRequests `
-                            -DefaultBranch $defaultBranch `
-                            -CommitSha $commitSha)
-                } else {
-                    @()
-                }
-                if ($discardedPullRequests.Count -gt 0) {
-                    throw (
-                        "Commit [$commitSha] cannot be released because its version label cannot be determined. " +
-                        'The following merged pull request(s) are associated with it but none matches the commit ' +
-                        "being released: $($discardedPullRequests -join '; '). " +
-                        'Refusing to fall back to a patch bump, because a wrong version published to the ' +
-                        'PowerShell Gallery cannot be reclaimed. Re-run the workflow against the merge commit ' +
-                        'of the pull request you intend to release.'
-                    )
-                }
-                Write-Host "::notice::No pull request is associated with commit [$commitSha]."
-            }
+            $response = Invoke-GitHubAPI -ApiEndpoint "/repos/$owner/$repo/commits/$Sha/pulls" -Method GET
+            $response.Response
         }
+    }
+    $resolution = Resolve-ReleasePullRequest @resolveParams
+    if ($resolution.Resolved) {
+        $pullRequest = $resolution.PullRequest
     }
 
     $pullRequestIsMerged = if ($null -eq $pullRequest) {

--- a/.github/actions/Get-PSModuleSettings/tests/Get-PSModuleSettings.Helpers.Tests.ps1
+++ b/.github/actions/Get-PSModuleSettings/tests/Get-PSModuleSettings.Helpers.Tests.ps1
@@ -126,6 +126,214 @@ Describe 'Select-PullRequestForPush' {
     }
 }
 
+Describe 'Resolve-ReleasePullRequest' {
+    BeforeAll {
+        $script:mergedPullRequest = [pscustomobject]@{
+            Number           = 64
+            Base             = [pscustomobject]@{ Ref = 'main' }
+            merged_at        = '2026-09-02T09:02:24Z'
+            merge_commit_sha = 'released-sha'
+            Labels           = @([pscustomobject]@{ Name = 'minor' })
+        }
+    }
+
+    It 'resolves the merged pull request for a push to the default branch' {
+        $result = Resolve-ReleasePullRequest -EventName push `
+            -CommitSha 'released-sha' `
+            -DefaultBranch main `
+            -IsPushToDefaultBranch $true `
+            -GetAssociatedPullRequest { @($script:mergedPullRequest) }
+
+        $result.Resolved | Should -BeTrue
+        $result.PullRequest.Number | Should -Be 64
+    }
+
+    It 'resolves the merged pull request for a manual dispatch on the default branch' {
+        # Regression guard for issue #530. Association was gated on the push event, so a recovery
+        # dispatch resolved no pull request, discarded the merged pull request's version label, and
+        # silently released a patch bump instead of the labeled minor bump.
+        $result = Resolve-ReleasePullRequest -EventName workflow_dispatch `
+            -CommitSha 'released-sha' `
+            -DefaultBranch main `
+            -IsManualDispatchToDefaultBranch $true `
+            -GetAssociatedPullRequest { @($script:mergedPullRequest) }
+
+        $result.Resolved | Should -BeTrue
+        $result.PullRequest.Number | Should -Be 64
+        @($result.PullRequest.Labels.Name) | Should -Be @('minor')
+    }
+
+    It 'does not look up a pull request for a manual dispatch outside the default branch' {
+        $lookups = @{ Count = 0 }
+        $result = Resolve-ReleasePullRequest -EventName workflow_dispatch `
+            -CommitSha 'released-sha' `
+            -DefaultBranch main `
+            -IsManualDispatchToDefaultBranch $false `
+            -GetAssociatedPullRequest ({ $lookups.Count++; @() }.GetNewClosure())
+
+        $result.Resolved | Should -BeFalse
+        $result.PullRequest | Should -BeNullOrEmpty
+        $lookups.Count | Should -Be 0
+    }
+
+    It 'does not look up a pull request for a scheduled run' {
+        $lookups = @{ Count = 0 }
+        $result = Resolve-ReleasePullRequest -EventName schedule `
+            -CommitSha 'released-sha' `
+            -DefaultBranch main `
+            -GetAssociatedPullRequest ({ $lookups.Count++; @() }.GetNewClosure())
+
+        $result.Resolved | Should -BeFalse
+        $lookups.Count | Should -Be 0
+    }
+
+    It 'does not look up a pull request without a commit' {
+        $lookups = @{ Count = 0 }
+        $result = Resolve-ReleasePullRequest -EventName workflow_dispatch `
+            -CommitSha '' `
+            -DefaultBranch main `
+            -IsManualDispatchToDefaultBranch $true `
+            -GetAssociatedPullRequest ({ $lookups.Count++; @() }.GetNewClosure())
+
+        $result.Resolved | Should -BeFalse
+        $lookups.Count | Should -Be 0
+    }
+
+    It 'releases a directly pushed commit that has no associated pull request' {
+        $result = Resolve-ReleasePullRequest -EventName workflow_dispatch `
+            -CommitSha 'direct-push-sha' `
+            -DefaultBranch main `
+            -IsManualDispatchToDefaultBranch $true `
+            -GetAssociatedPullRequest { @() }
+
+        $result.Resolved | Should -BeTrue
+        $result.PullRequest | Should -BeNullOrEmpty
+    }
+
+    It 'tolerates an association response that yields a null element' {
+        $result = Resolve-ReleasePullRequest -EventName push `
+            -CommitSha 'direct-push-sha' `
+            -DefaultBranch main `
+            -IsPushToDefaultBranch $true `
+            -GetAssociatedPullRequest { $null }
+
+        $result.Resolved | Should -BeTrue
+        $result.PullRequest | Should -BeNullOrEmpty
+    }
+
+    It 'fails rather than release a patch bump when a merged pull request does not match the commit' {
+        # A silently wrong version cannot be withdrawn from the PowerShell Gallery, so a commit whose
+        # version label cannot be determined must stop the run.
+        $otherMerge = [pscustomobject]@{
+            Number           = 412
+            Base             = [pscustomobject]@{ Ref = 'main' }
+            merged_at        = '2026-09-01T00:00:00Z'
+            merge_commit_sha = 'merge-of-412'
+        }
+
+        $getAssociated = { @($otherMerge) }.GetNewClosure()
+        {
+            Resolve-ReleasePullRequest -EventName workflow_dispatch `
+                -CommitSha 'released-sha' `
+                -DefaultBranch main `
+                -IsManualDispatchToDefaultBranch $true `
+                -GetAssociatedPullRequest $getAssociated
+        } | Should -Throw '*#412*merge-of-412*cannot be reclaimed*'
+    }
+
+    It 'releases the default patch bump when only an open pull request claims the commit' {
+        # The commit association endpoint also returns open pull requests whose branch contains the
+        # commit. They carry no release intent and must not fail a direct default-branch push.
+        $openPullRequest = [pscustomobject]@{
+            Number           = 411
+            Base             = [pscustomobject]@{ Ref = 'main' }
+            merged_at        = $null
+            merge_commit_sha = 'not-merged-yet'
+        }
+
+        $result = Resolve-ReleasePullRequest -EventName push `
+            -CommitSha 'direct-push-sha' `
+            -DefaultBranch main `
+            -IsPushToDefaultBranch $true `
+            -GetAssociatedPullRequest ({ @($openPullRequest) }.GetNewClosure())
+
+        $result.Resolved | Should -BeTrue
+        $result.PullRequest | Should -BeNullOrEmpty
+    }
+
+    It 'does not fail a feature-branch push whose commit belongs to another merged pull request' {
+        $otherMerge = [pscustomobject]@{
+            Number           = 412
+            Base             = [pscustomobject]@{ Ref = 'main' }
+            merged_at        = '2026-09-01T00:00:00Z'
+            merge_commit_sha = 'merge-of-412'
+        }
+
+        $result = Resolve-ReleasePullRequest -EventName push `
+            -CommitSha 'feature-sha' `
+            -DefaultBranch main `
+            -IsPushToDefaultBranch $false `
+            -GetAssociatedPullRequest ({ @($otherMerge) }.GetNewClosure())
+
+        $result.Resolved | Should -BeTrue
+        $result.PullRequest | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-DiscardedReleasePullRequest' {
+    It 'reports a merged default-branch pull request that does not match the released commit' {
+        $pullRequests = @(
+            [pscustomobject]@{
+                Number           = 412
+                Base             = [pscustomobject]@{ Ref = 'main' }
+                merged_at        = '2026-08-15T00:00:00Z'
+                merge_commit_sha = 'merge-of-412'
+            }
+        )
+
+        $result = @(Get-DiscardedReleasePullRequest -PullRequest $pullRequests -DefaultBranch main -CommitSha 'other-sha')
+
+        $result.Count | Should -Be 1
+        $result[0] | Should -BeLike '*#412*merge-of-412*'
+    }
+
+    It 'reports nothing when the merged pull request matches the released commit' {
+        $pullRequests = @(
+            [pscustomobject]@{
+                Number           = 390
+                Base             = [pscustomobject]@{ Ref = 'main' }
+                merged_at        = '2026-08-15T00:00:00Z'
+                merge_commit_sha = 'released-sha'
+            }
+        )
+
+        $result = @(Get-DiscardedReleasePullRequest -PullRequest $pullRequests -DefaultBranch main -CommitSha 'released-sha')
+
+        $result.Count | Should -Be 0
+    }
+
+    It 'ignores a pull request merged into a branch other than the default branch' {
+        $pullRequests = @(
+            [pscustomobject]@{
+                Number           = 401
+                Base             = [pscustomobject]@{ Ref = 'release/1.x' }
+                merged_at        = '2026-08-15T00:00:00Z'
+                merge_commit_sha = 'merge-of-401'
+            }
+        )
+
+        $result = @(Get-DiscardedReleasePullRequest -PullRequest $pullRequests -DefaultBranch main -CommitSha 'released-sha')
+
+        $result.Count | Should -Be 0
+    }
+
+    It 'reports nothing for a commit with no associated pull request' {
+        $result = @(Get-DiscardedReleasePullRequest -PullRequest @() -DefaultBranch main -CommitSha 'direct-push-sha')
+
+        $result.Count | Should -Be 0
+    }
+}
+
 Describe 'Get-FilesFromGitTree' {
     It 'returns only files from a complete tree response' {
         $tree = [pscustomobject]@{

--- a/.github/actions/Resolve-PSModuleVersion/tests/Resolve-PSModuleVersion.Helpers.Tests.ps1
+++ b/.github/actions/Resolve-PSModuleVersion/tests/Resolve-PSModuleVersion.Helpers.Tests.ps1
@@ -523,6 +523,46 @@ Describe 'Resolve-PSModuleVersion' {
             $result.Labels | Should -BeNullOrEmpty
             $result.IsDirectRelease | Should -BeTrue
         }
+
+        It 'honours the version label from a pull request resolved by a default-branch dispatch' {
+            # Regression guard for issue #530. Before the fix, a manual dispatch resolved no pull
+            # request, so Context.PullRequest was null and the direct-release branch applied a patch
+            # bump. With the pull request resolved, the minor label must be carried through.
+            $settings = @{
+                Context = @{
+                    IsPushToDefaultBranch           = $false
+                    IsManualDispatchToDefaultBranch = $true
+                    DefaultBranch                   = 'main'
+                    PullRequest                     = @{
+                        Number  = 64
+                        HeadRef = 'feature/recovered-release'
+                        Labels  = @('minor')
+                    }
+                }
+            } | ConvertTo-Json -Depth 5
+
+            $result = Get-GitHubPullRequest -SettingsJson $settings
+
+            $result.Number | Should -Be 64
+            $result.Labels | Should -Be @('minor')
+            $result.IsDirectRelease | Should -BeNullOrEmpty
+        }
+
+        It 'creates default patch context for a direct default-branch dispatch' {
+            $settings = @{
+                Context = @{
+                    IsPushToDefaultBranch           = $false
+                    IsManualDispatchToDefaultBranch = $true
+                    DefaultBranch                   = 'main'
+                    PullRequest                     = $null
+                }
+            } | ConvertTo-Json -Depth 5
+
+            $result = Get-GitHubPullRequest -SettingsJson $settings
+
+            $result.Number | Should -BeNullOrEmpty
+            $result.IsDirectRelease | Should -BeTrue
+        }
     }
 
     Describe 'Resolve-ReleaseDecision' {
@@ -532,6 +572,47 @@ Describe 'Resolve-PSModuleVersion' {
 
             $result.ShouldPublish | Should -BeTrue
             $result.PatchRelease | Should -BeTrue
+        }
+
+        It 'resolves the labeled minor version once a recovery dispatch supplies pull request context' {
+            # End-to-end guard for issue #530, using the reproduction numbers from
+            # MariusStorhaug/MariusTestModule: latest release v0.4.13 and merged pull request #64
+            # labeled 'minor', so the correct release is 0.5.0. This asserts the version consequence
+            # of the two possible contexts a default-branch dispatch can produce. Get-PSModuleSettings
+            # decides which one it is; that decision is guarded by
+            # Test-ShouldResolveAssociatedPullRequest in the settings action tests.
+            $configuration = Get-TestConfiguration
+            $versionFor = {
+                param($SettingsJson)
+                $pullRequest = Get-GitHubPullRequest -SettingsJson $SettingsJson
+                $decision = Resolve-ReleaseDecision -Configuration $configuration -PullRequest $pullRequest
+                $resolved = Get-ResolvedModuleVersion -GitHubVersion ([PSSemVer]'0.4.13') `
+                    -PSGalleryVersion ([PSSemVer]'0.4.13') `
+                    -Decision $decision `
+                    -Configuration $configuration `
+                    -ModuleName 'MariusTestModule'
+                $resolved.ToString()
+            }
+
+            $dispatchContext = @{
+                IsPushToDefaultBranch           = $false
+                IsManualDispatchToDefaultBranch = $true
+                DefaultBranch                   = 'main'
+            }
+
+            $withoutPullRequest = & $versionFor (@{
+                    Context = $dispatchContext + @{ PullRequest = $null }
+                } | ConvertTo-Json -Depth 5)
+            $withPullRequest = & $versionFor (@{
+                    Context = $dispatchContext + @{
+                        PullRequest = @{ Number = 64; HeadRef = 'feature/recovered-release'; Labels = @('minor') }
+                    }
+                } | ConvertTo-Json -Depth 5)
+
+            # The silent downgrade the defect produced.
+            $withoutPullRequest | Should -Be 'v0.4.14'
+            # The version the merged pull request's label asks for.
+            $withPullRequest | Should -Be 'v0.5.0'
         }
 
         It 'does not publish an unlabeled prerelease when AutoPatching is disabled' {


### PR DESCRIPTION
A manual dispatch on the default branch now resolves the merged pull request for the dispatched commit and applies its version label, instead of discarding the label and silently releasing a patch bump.

## Fixed: a recovery dispatch releases the intended version

Manual dispatch on the default branch is the documented recovery route when a release run fails or is cancelled. In that exact scenario the label that determines the version bump was ignored, and the run published a version nobody asked for. A PowerShell Gallery version cannot be reclaimed once taken.

Validated on `MariusStorhaug/MariusTestModule`. The same commit `705564d`, the merge commit of a `Minor`-labelled pull request, with the latest release at `v0.4.13`:

| | Before | After |
| --- | --- | --- |
| Associated pull request | none | #64 |
| Bump | Patch | Minor |
| Resolved version | `v0.4.14` | `v0.5.0` |

A `push` of the same commit already resolved `v0.5.0`, so a dispatch now behaves the same as the push it replaces.

No repository configuration changes are needed. A workflow that previously resolved the wrong version on a recovery dispatch resolves the intended version on the next run.

A dispatch on a commit pushed directly to the default branch still releases the default patch bump, because there is no label to honour.

## Added: a version label that cannot be determined now fails the run

When the commit being released belongs to a pull request that was merged into the default branch but is not that pull request's merge commit, the version label cannot be determined. The run now stops with an actionable message instead of assuming a patch bump:

```text
Commit [629ea31...] cannot be released because its version label cannot be determined. The
following merged pull request(s) are associated with it but none matches the commit being
released: #64 was merged into [main] with merge commit [705564d...]. Refusing to fall back to a
patch bump, because a wrong version published to the PowerShell Gallery cannot be reclaimed.
Re-run the workflow against the merge commit of the pull request you intend to release.
```

A loud failure is strictly better than a silently wrong version that cannot be withdrawn.

---
<details>
<summary>Technical details</summary>

- `.github/actions/Get-PSModuleSettings/src/main.ps1` — pull request association was gated on `if ($isPush -and $commitSha)`. For a `workflow_dispatch` the gate was false even though both facts it needed were already true one line above: `$commitSha` is populated from `GITHUB_SHA` for every non-push event, and `$isManualDispatchToDefaultBranch` was already computed. The event was fully recognised; only the lookup was skipped. With `$pullRequest` left null, `Context.PullRequest` serialised as null, `Get-GitHubPullRequest` took its `IsPushToDefaultBranch -or IsManualDispatchToDefaultBranch` branch and returned `Labels = @()` with `IsDirectRelease = $true`, and `Resolve-ReleaseDecision` then set `$patchRelease` through `$Configuration.AutoPatching -or $isDirectStableRelease`. The label never reached the decision, so a recovery dispatch was indistinguishable from a direct push. The gate is now `($isPush -or $IsManualDispatchToDefaultBranch)`.
- `Select-PullRequestForPush` needed no change. The commit association endpoint returns the pull request for a squash-merge commit with `base.ref` equal to the default branch, `merged_at` set, and `merge_commit_sha` exactly equal to the released commit, so all three of its criteria already hold. Confirmed against the live API for `705564d` (#64) and `68696b6` (#529).
- The no-pull-request case is decided deliberately, and not as the issue first proposed. Failing whenever no pull request resolves would break a legitimate direct push to the default branch, which has no label to honour and correctly releases a patch bump. The distinction encoded instead is the one the issue itself identifies: *no pull request carries release intent* (proceed) versus *a merged default-branch pull request exists but does not match the commit* (fail). New `Get-DiscardedReleasePullRequest` reports only the second case.
- Two cases are deliberately not failures, both verified against live API responses rather than assumed. The association endpoint also returns **open** pull requests whose branch contains the commit — confirmed for `629ea31` returning #64 while still open — so treating those as failures would break every direct default-branch push made while a pull request is open. **Pushes to non-default branches** pass through the same gate but have no release to get wrong, so the guard is scoped to `$isPushToDefaultBranch -or $isManualDispatchToDefaultBranch`.
- `.github/actions/Get-PSModuleSettings/src/Get-PSModuleSettings.Helpers.psm1` — the gate, the selection, and the no-pull-request decision were inline in `main.ps1`, which needs a large environment and a live API to run, so the composed logic that produced the wrong version could not be tested. They are now `Resolve-ReleasePullRequest`, with the GitHub lookup injected as a `[scriptblock]`. The behaviour is covered directly instead of being re-implemented in a test, which would have proved nothing about the shipped code. The `LogGroup` boundary is safe here: `Set-GitHubLogGroup` dot-sources its script block, verified empirically, so assignments and `throw` propagate to the caller.
- `@($response.Response)` became `@($response.Response | Where-Object { $null -ne $_ })`. `@($null)` has `Count` 1, not 0, so an empty association response produced a single-element array containing `$null`. `Select-PullRequestForPush` tolerated it, but the new guard iterates the same collection and would otherwise inspect a null element. Covered by a test that returns `$null` from the lookup.
- `.github/actions/Get-PSModuleSettings/tests/` and `.github/actions/Resolve-PSModuleVersion/tests/` — ten new tests. Each was verified to fail against the specific defect it guards, by reverting each behaviour independently rather than by deleting the new functions, so the assertions are known to catch behaviour and not absence: narrowing the gate back to `$isPush` fails 3, disabling the no-pull-request guard fails 2, and both together fail 4. The version-action test asserts both versions the two possible dispatch contexts produce, `v0.4.14` and `v0.5.0`, so it pins the actual consequence rather than an intermediate flag.
- Test traps from #529 were avoided. Shims are not used here, so `Set-Item function:global:X` teardown is not involved. Where a test needs to observe whether the injected lookup ran, it uses a hashtable captured by `GetNewClosure()` rather than a `$script:` flag, because a flag set inside a script block invoked with `&` does not propagate out. One authoring trap was hit and fixed during development: `{ ... }.GetNewClosure()` passed as an argument inside a `Should -Throw` script block is evaluated in the wrong scope and does not capture, so the closure is now assigned to a variable first.
- The full action suite passes locally under the configuration `Test-Actions.yml` builds, including `Run.Parallel` and `Run.Shuffle`: 90 tests, 0 failures. PSScriptAnalyzer is clean against `.github/linters/.powershell-psscriptanalyzer.psd1`.
- Validation used temporary branches that force `WhatIf: true` on all three publish steps in `Publish-Module.yml`, so no Gallery version and no GitHub release could be created by any reproduction or validation run. Confirmed before triggering anything, and confirmed after: the Gallery and the latest release are both still `0.4.13`. Those branches are not part of this pull request, and are deleted once the fix ships.

| Changed surface | Standards checked | Framework docs checked | Result |
| --- | --- | --- | --- |
| `.github/actions/Get-PSModuleSettings/src/**` (PowerShell) | Coding standards, error handling | Plan stage contract | Aligned |
| `.github/actions/Get-PSModuleSettings/tests/**` (Pester) | Pester test standards | Action test layout | Aligned |
| `.github/actions/Resolve-PSModuleVersion/tests/**` (Pester) | Pester test standards | Action test layout | Aligned |

</details>

<details>
<summary>Relevant issues (or links)</summary>

- Resolves PSModule/Process-PSModule#530

### Related work

- References PSModule/Process-PSModule#529

</details>
